### PR TITLE
Implement Sale constructor

### DIFF
--- a/packages/contracts/contracts/token/Sale.sol
+++ b/packages/contracts/contracts/token/Sale.sol
@@ -38,6 +38,24 @@ interface ISale {
  *
  * @dev Remove `abstract` when fully implemented
  */
-abstract contract Sale is ISale {
+contract Sale is ISale {
+    address public token;
+    address public paymentToken;
 
+    constructor(address _token, address _paymentToken) {
+        token = _token;
+        paymentToken = _paymentToken;
+    }
+
+    function calculateAmount(uint256 _paymentAmount)
+        external
+        view
+        returns (uint256)
+    {
+        revert("not implemented");
+    }
+
+    function buy(uint256 _paymentAmount) external {
+        revert("not implemented");
+    }
 }

--- a/packages/contracts/deploy/sale.ts
+++ b/packages/contracts/deploy/sale.ts
@@ -6,13 +6,13 @@ const func: DeployFunction = async function (hre) {
   const { deploy, get } = hre.deployments;
 
   const aUSD = await get("aUSD");
+  const citizend = await get("Citizend");
 
-  // await deploy("aUSD", {
-  //   contract: "MockERC20",
-  //   log: true,
-  //   from: deployer,
-  //   args: ["Acala USD", "aUSD"],
-  // });
+  await deploy("Sale", {
+    log: true,
+    from: deployer,
+    args: [citizend.address, aUSD.address],
+  });
 };
 
 func.id = "sale";

--- a/packages/contracts/test/contracts/token/Sale.ts
+++ b/packages/contracts/test/contracts/token/Sale.ts
@@ -6,11 +6,12 @@ import {
   MockERC20,
   MockERC20__factory,
   Sale,
+  Sale__factory,
   Citizend,
   Citizend__factory,
 } from "../../../src/types";
 
-describe("Citizend", () => {
+describe("Sale", () => {
   let owner: SignerWithAddress;
   let alice: SignerWithAddress;
 
@@ -25,16 +26,19 @@ describe("Citizend", () => {
 
     const aUSDDeployment = await deployments.get("aUSD");
     const citizendDeployment = await deployments.get("Citizend");
+    const saleDeployment = await deployments.get("Sale");
 
     aUSD = MockERC20__factory.connect(aUSDDeployment.address, owner);
     citizend = Citizend__factory.connect(citizendDeployment.address, owner);
+    sale = Sale__factory.connect(saleDeployment.address, owner);
   });
 
   beforeEach(() => fixture());
 
   describe("constructor", () => {
-    it("", async () => {
-      console.log(await aUSD.balanceOf(alice.address));
+    it("sets the correct params", async () => {
+      expect(await sale.token()).to.equal(citizend.address);
+      expect(await sale.paymentToken()).to.equal(aUSD.address);
     });
   });
 


### PR DESCRIPTION
Why:
* So that we can start implementing the Sale contract

How:
* Adding the constructor to the Sale contract
* Updating the `deploy/sale.ts` script to deploy the Sale contract and
  wait for the deployment of the Citizend contract
* Adding a constructor test that checks if the arguments are correctly
  set, and in the right order
