### PR TITLE
Remove ignored folder

### DIFF
--- a/packages/contracts/.vscode/settings.json
+++ b/packages/contracts/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-  "cSpell.words": ["citizend", "CTND"],
-  "prettier.prettierPath": "../../node_modules/prettier"
-}


### PR DESCRIPTION
Why:
* The `.vscode` folder is ignored in `.gitignore` and it shouldn't be
  in the repo

How:
* Removing the `.vscode` folder
