### PR TITLE
Naive buy function implementation of the Sale contract

### DIFF
--- a/packages/contracts/contracts/token/Sale.sol
+++ b/packages/contracts/contracts/token/Sale.sol
@@ -2,6 +2,8 @@
 pragma solidity =0.8.12;
 
 import {IVesting} from "./Vesting.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "hardhat/console.sol";
 
 interface ISale {
     /// The $CTND token
@@ -42,6 +44,8 @@ contract Sale is ISale {
     address public token;
     address public paymentToken;
 
+    event Purchase(address from, uint256 amount);
+
     constructor(address _token, address _paymentToken) {
         token = _token;
         paymentToken = _paymentToken;
@@ -56,6 +60,16 @@ contract Sale is ISale {
     }
 
     function buy(uint256 _paymentAmount) external {
-        revert("not implemented");
+        require(_paymentAmount > 0, "can't be zero");
+
+        IERC20(paymentToken).transferFrom(
+            msg.sender,
+            address(this),
+            _paymentAmount
+        );
+
+        // vesting.registerNewPublicVesting(msg.sender, 1);
+
+        emit Purchase(msg.sender, _paymentAmount);
     }
 }

--- a/packages/contracts/test/contracts/token/Sale.ts
+++ b/packages/contracts/test/contracts/token/Sale.ts
@@ -31,6 +31,9 @@ describe("Sale", () => {
     aUSD = MockERC20__factory.connect(aUSDDeployment.address, owner);
     citizend = Citizend__factory.connect(citizendDeployment.address, owner);
     sale = Sale__factory.connect(saleDeployment.address, owner);
+
+    const allowance = ethers.constants.MaxUint256;
+    await aUSD.connect(alice).approve(sale.address, allowance);
   });
 
   beforeEach(() => fixture());
@@ -46,7 +49,15 @@ describe("Sale", () => {
     it("allows paying 0.30 $aUSD for 1 $CTND");
     it("allows payment 300 $aUSD for 1000 $CTND");
     it("fails if not enough $CTND are available");
-    it("emits a Purchase event");
+
+    it("emits a Purchase event", async () => {
+      const paymentAmount = ethers.utils.parseUnits("1");
+
+      expect(await sale.connect(alice).buy(paymentAmount))
+        .to.emit(sale, "Purchase")
+        .withArgs(alice.address, paymentAmount);
+    });
+
     it("sends tokens into vesting with correct parameters");
     it("correctly handles multiple purchases from the same account");
   });


### PR DESCRIPTION
Why:
* So that we can start reasoning about the flow of how this will work

How:
* Implementing a bare bones and incomplete version of the `buy` function
  that for now only transfers the `aUSD` from the buyer into the
  Sale contract
* Adding a `Purchase` event to the Sale contract that contains the buyer
  and the amount bought
* Adding a test for the event emission
