### PR TITLE
Set token price visibility to public

### DIFF
--- a/packages/contracts/contracts/token/Sale.sol
+++ b/packages/contracts/contracts/token/Sale.sol
@@ -44,7 +44,7 @@ contract Sale is ISale {
     address public token;
     address public paymentToken;
 
-    uint256 private tokenPrice;
+    uint256 public tokenPrice;
 
     event Purchase(address from, uint256 amount);
 


### PR DESCRIPTION
Why:
* The token price should be visible from the outside

How:
* Changing the visibility of `tokenPrice` from `private` to `public`
