### PR TITLE
Allow setting the start and end timestamps for the Sale contract

### DIFF
--- a/packages/contracts/contracts/token/Sale.sol
+++ b/packages/contracts/contracts/token/Sale.sol
@@ -51,21 +51,29 @@ contract Sale is ISale, AccessControl {
     address public vesting;
 
     uint256 public tokenPrice;
+    uint256 public start;
+    uint256 public end;
 
     event Purchase(address from, uint256 amount);
 
     constructor(
         uint256 _tokenPrice,
         address _token,
-        address _paymentToken
+        address _paymentToken,
+        uint256 _start,
+        uint256 _end
     ) {
         require(_tokenPrice > 0, "can't be zero");
         require(_token != address(0), "can't be zero");
         require(_paymentToken != address(0), "can't be zero");
+        require(_start > 0, "can't be zero");
+        require(_end > _start, "end date should be higher than start date");
 
         tokenPrice = _tokenPrice;
         token = _token;
         paymentToken = _paymentToken;
+        start = _start;
+        end = _end;
 
         _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
     }
@@ -91,6 +99,10 @@ contract Sale is ISale, AccessControl {
     }
 
     function buy(uint256 _paymentAmount) external {
+        require(
+            block.timestamp >= start && block.timestamp <= end,
+            "no active sale"
+        );
         require(_paymentAmount > 0, "can't be zero");
 
         IERC20(paymentToken).transferFrom(

--- a/packages/contracts/deploy/sale.ts
+++ b/packages/contracts/deploy/sale.ts
@@ -10,10 +10,15 @@ const func: DeployFunction = async function (hre) {
   const aUSD = await get("aUSD");
   const citizend = await get("Citizend");
 
+  const today = ethers.BigNumber.from(Math.round(new Date().getTime() / 1000));
+  const tomorrow = ethers.BigNumber.from(
+    Math.round(new Date().getTime() / 1000) + 60 * 60 * 24
+  );
+
   await deploy("Sale", {
     log: true,
     from: deployer,
-    args: [parseUnits("0.3"), citizend.address, aUSD.address],
+    args: [parseUnits("0.3"), citizend.address, aUSD.address, today, tomorrow],
   });
 };
 


### PR DESCRIPTION
Why:
* We need to only allow the sale to happen during a specific period of
  time, that should be configurable by an admin once the contract is
  deployed

How:
* Adding `startTimestamp` and `endTimestamp` variables to store the
  period of time in which the sale is active
* Adding a `require` to the `buy` function that checks if the
  transaction is ocurring during the alloted timeframe
* Adding a `setTimestamps` function to allow an admin to set the start
  and end timestamp
* Adding tests to the `setTimestamps` function
