### PR TITLE
Controller contract Project registration

### DIFF
--- a/packages/contracts/contracts/discovery/Controller.sol
+++ b/packages/contracts/contracts/discovery/Controller.sol
@@ -4,8 +4,13 @@ pragma solidity =0.8.12;
 import {IController} from "./IController.sol";
 import {ProjectHelpers} from "../libraries/ProjectHelpers.sol";
 
+import "hardhat/console.sol";
+
 contract Controller is IController {
     using ProjectHelpers for Project;
+
+    uint256 lastProjectId;
+    uint256 lastBatchId;
 
     mapping(uint256 => Project) public projects;
 
@@ -16,6 +21,8 @@ contract Controller is IController {
 
     /// Batch => projectId => votes
     mapping(uint256 => mapping(uint256 => uint256)) public projectVoteCount;
+
+    event RegisterProject(uint256 projectId);
 
     /// @inheritdoc IController
     function getProject(uint256 id) external view returns (Project memory) {
@@ -29,6 +36,29 @@ contract Controller is IController {
 
     function approveProjectByOwner(uint256 id) external {
         revert("not implemented");
+    }
+
+    function registerProject(
+        address _token,
+        uint256 _saleSupply,
+        uint256 _rate
+    ) external {
+        require(
+            projects[lastProjectId].status == ProjectStatus.Uninitialized,
+            "project already exists"
+        );
+
+        emit RegisterProject(lastProjectId);
+
+        projects[lastProjectId] = Project({
+            id: lastProjectId,
+            token: _token,
+            saleSupply: _saleSupply,
+            rate: _rate,
+            status: ProjectStatus.Created
+        });
+
+        lastProjectId++;
     }
 
     function createBatch(

--- a/packages/contracts/contracts/discovery/IController.sol
+++ b/packages/contracts/contracts/discovery/IController.sol
@@ -5,6 +5,13 @@ pragma solidity =0.8.12;
 ///   * Creating batches
 ///   * Whitelisting companies
 interface IController {
+    enum ProjectStatus {
+        Uninitialized,
+        Created,
+        Whitelisted,
+        InBatch
+    }
+
     /// Information on an individual project
     struct Project {
         uint256 id;
@@ -14,6 +21,8 @@ interface IController {
         uint256 saleSupply;
         /// Exchange rate, multiplied by 10e18
         uint256 rate;
+        /// ProjectStatus
+        ProjectStatus status;
     }
 
     /// Definition of a time period
@@ -50,6 +59,13 @@ interface IController {
     function createBatch(
         uint256[] calldata projectIds,
         Period calldata votingPeriod
+    ) external;
+
+    /// Registers a new Project
+    function registerProject(
+        address _token,
+        uint256 _saleSupply,
+        uint256 _rate
     ) external;
 
     /// How many votes have been cast by a user on a given batch

--- a/packages/contracts/test/discovery/Controller.ts
+++ b/packages/contracts/test/discovery/Controller.ts
@@ -4,16 +4,19 @@ import { expect } from "chai";
 import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { Controller, Controller__factory } from "../../src/types";
 
+const { parseUnits } = ethers.utils;
+
 describe("Controller", () => {
   let owner: SignerWithAddress;
   let alice: SignerWithAddress;
+  let bob: SignerWithAddress;
 
   let controller: Controller;
 
   const fixture = deployments.createFixture(async ({ deployments, ethers }) => {
     await deployments.fixture(["controller"]);
 
-    [owner, alice] = await ethers.getSigners();
+    [owner, alice, bob] = await ethers.getSigners();
 
     const controllerDeployment = await deployments.get("Controller");
 
@@ -27,5 +30,53 @@ describe("Controller", () => {
 
   describe("constructor", () => {
     it("sets the correct params", async () => {});
+  });
+
+  describe("registerProject", () => {
+    it("registers a project", async () => {
+      await controller.registerProject(
+        alice.address,
+        parseUnits("1000"),
+        parseUnits("2")
+      );
+
+      const project = await controller.getProject(0);
+
+      expect(project.id).to.eq(0);
+      expect(project.token).to.eq(alice.address);
+      expect(project.saleSupply).to.eq(parseUnits("1000"));
+      expect(project.rate).to.eq(parseUnits("2"));
+      expect(project.status).to.eq(1);
+    });
+
+    it("emits a RegisterProject event", async () => {
+      expect(
+        await controller.registerProject(
+          alice.address,
+          parseUnits("1000"),
+          parseUnits("2")
+        )
+      )
+        .to.emit(controller, "RegisterProject")
+        .withArgs(0);
+    });
+
+    it("increases the project counter", async () => {
+      await controller.registerProject(
+        alice.address,
+        parseUnits("1000"),
+        parseUnits("2")
+      );
+
+      expect(
+        await controller.registerProject(
+          bob.address,
+          parseUnits("1000"),
+          parseUnits("2")
+        )
+      )
+        .to.emit(controller, "RegisterProject")
+        .withArgs(1);
+    });
   });
 });


### PR DESCRIPTION
Why:
* Initial implementation of the `registerProject` function for the
  Controller contract

How:
* Adding a `registerProject` function that allows adding a new
  Project to the `projects`
* Adding a `RegisterProject` event and a `ProjectStatus` enum
* Adding `lastProjectId` and `lastBatchId` to keep track of the last
  generated Project and Batch, respectively
