### PR TITLE
First stab at Staking

### DIFF
--- a/packages/contracts/contracts/discovery/IStaking.sol
+++ b/packages/contracts/contracts/discovery/IStaking.sol
@@ -8,5 +8,5 @@ interface IStaking {
 
     function withdraw(uint256 amount) external;
 
-    function getStake() external view returns (uint256);
+    function rebond(uint256 amount) external;
 }

--- a/packages/contracts/contracts/discovery/IStaking.sol
+++ b/packages/contracts/contracts/discovery/IStaking.sol
@@ -2,11 +2,47 @@
 pragma solidity =0.8.12;
 
 interface IStaking {
+    /**
+     * Stakes the given amount of tokens, using the `msg.sender` as the
+     * staker.
+     *
+     * @dev Emits a `StakeFunds` event.
+     *
+     * @param amount The amount of tokens to stake.
+     */
     function stake(uint256 amount) external;
 
+    /**
+     * Unbonds the given amount of tokens, using the `msg.sender` as the
+     * staker. The staker must have already staked the given amount of
+     * tokens.
+     *
+     * @dev Emits a `Unbond` event.
+     * @dev Uses a mapping to handle the different unbondings, but from the
+     * caller's side it's treated as a single pool.
+     *
+     * @param amount The amount of tokens to unbond.
+     */
     function unbond(uint256 amount) external;
 
-    function withdraw(uint256 amount) external;
-
+    /**
+     * Rebonds the given amount of tokens for `msg.sender`. It requires that
+     * there are enough funds that are still unbonding or that have been
+     * unbonded but not yet withdrawn.
+     *
+     * @dev Emits a `Rebond` event.
+     *
+     * @param amount The amount of tokens to rebond.
+     */
     function rebond(uint256 amount) external;
+
+    /**
+     * Withdraws the given amount of tokens. Requires that the staker has the
+     * amount unbonded.
+     *
+     * @dev Emits a `Withdraw` event.
+     *
+     * @param amount The amount of tokens to withdraw.
+     */
+    function withdraw(uint256 amount) external;
 }

--- a/packages/contracts/contracts/discovery/IStaking.sol
+++ b/packages/contracts/contracts/discovery/IStaking.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity =0.8.12;
+
+interface IStaking {
+    function stake(uint256 amount) external;
+
+    function unbond(uint256 amount) external;
+
+    function withdraw(uint256 amount) external;
+
+    function getStake() external view returns (uint256);
+}

--- a/packages/contracts/contracts/discovery/Staking.sol
+++ b/packages/contracts/contracts/discovery/Staking.sol
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity =0.8.12;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+import {IStaking} from "./IStaking.sol";
+import {DateTime} from "../libraries/DateTime.sol";
+
+contract Staking is IStaking {
+    using DateTime for uint256;
+    using SafeERC20 for IERC20;
+
+    struct Stake {
+        uint256 actualAmount;
+        uint256 availableAmount;
+        Unbonding[] unbondings;
+    }
+
+    struct Unbonding {
+        uint256 amount;
+        uint256 time;
+    }
+
+    mapping(address => Stake) public stakes;
+    address public immutable token;
+
+    uint256 public constant UNBONDING_PERIOD_IN_DAYS = 28;
+
+    constructor(address _token) {
+        token = _token;
+    }
+
+    function stake(uint256 _amount) public {
+        stakes[msg.sender].actualAmount += _amount;
+        stakes[msg.sender].availableAmount += _amount;
+
+        IERC20(token).safeTransferFrom(msg.sender, address(this), _amount);
+    }
+
+    function unbond(uint256 amount) public {
+        Stake storage _stake = stakes[msg.sender];
+        require(_stake.availableAmount >= amount, "not enough funds");
+        Unbonding memory unbonding = Unbonding(
+            amount,
+            DateTime.addDays(block.timestamp, UNBONDING_PERIOD_IN_DAYS)
+        );
+
+        _stake.unbondings.push(unbonding);
+        _stake.availableAmount -= amount;
+    }
+
+    function withdraw(uint256 amount) public {
+        Stake storage _stake = stakes[msg.sender];
+        require(_stake.actualAmount >= amount, "not enough funds");
+        uint256 withdrawableAmount;
+        uint256[] memory toBeRemovedUnbondings;
+
+        for (uint256 i = 0; i < _stake.unbondings.length; i++) {
+            Unbonding storage unbonding = _stake.unbondings[i];
+            if (unbonding.time > block.timestamp) {
+                break;
+            }
+
+            if (unbonding.amount >= amount) {
+                unbonding.amount -= amount;
+                withdrawableAmount += amount;
+                break;
+            } else {
+                withdrawableAmount += unbonding.amount;
+                toBeRemovedUnbondings[toBeRemovedUnbondings.length - 1] = i;
+            }
+        }
+
+        _removeUnbondings(toBeRemovedUnbondings);
+
+        require(withdrawableAmount >= amount, "not enough unbonded funds");
+        _stake.actualAmount -= amount;
+        IERC20(token).transfer(msg.sender, withdrawableAmount);
+    }
+
+    function getStake() public view returns (uint256) {
+        return stakes[msg.sender].availableAmount;
+    }
+
+    function _removeUnbondings(uint256[] memory indexes) public {
+        Unbonding[] storage unbondings = stakes[msg.sender].unbondings;
+
+        for (uint256 i = 0; i < indexes.length; i++) {
+            unbondings[i] = unbondings[unbondings.length - 1];
+            unbondings.pop();
+        }
+    }
+}

--- a/packages/contracts/contracts/discovery/Staking.sol
+++ b/packages/contracts/contracts/discovery/Staking.sol
@@ -87,7 +87,7 @@ contract Staking is IStaking {
         Unbonding[] storage unbondings = stakes[msg.sender].unbondings;
 
         for (uint256 i = 0; i < indexes.length; i++) {
-            unbondings[i] = unbondings[unbondings.length - 1];
+            unbondings[indexes[i]] = unbondings[unbondings.length - 1];
             unbondings.pop();
         }
     }

--- a/packages/contracts/contracts/discovery/Staking.sol
+++ b/packages/contracts/contracts/discovery/Staking.sol
@@ -5,10 +5,8 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 import {IStaking} from "./IStaking.sol";
-import {DateTime} from "../libraries/DateTime.sol";
 
 contract Staking is IStaking {
-    using DateTime for uint256;
     using SafeERC20 for IERC20;
 
     struct Stake {
@@ -27,7 +25,7 @@ contract Staking is IStaking {
     mapping(address => Stake) public stakes;
     address public immutable token;
 
-    uint256 public constant UNBONDING_PERIOD_IN_DAYS = 28;
+    uint256 public constant UNBONDING_PERIOD = 28 days;
 
     constructor(address _token) {
         token = _token;
@@ -45,7 +43,7 @@ contract Staking is IStaking {
         require(_stake.availableAmount >= amount, "not enough funds");
         Unbonding memory unbonding = Unbonding(
             amount,
-            DateTime.addDays(block.timestamp, UNBONDING_PERIOD_IN_DAYS)
+            block.timestamp + UNBONDING_PERIOD
         );
 
         _stake.unbondings.push(unbonding);
@@ -75,9 +73,8 @@ contract Staking is IStaking {
             }
         }
 
-        _removeUnbondings(toBeRemovedUnbondings);
-
         require(withdrawableAmount >= amount, "not enough unbonded funds");
+        _removeUnbondings(toBeRemovedUnbondings);
         _stake.actualAmount -= amount;
         IERC20(token).transfer(msg.sender, withdrawableAmount);
     }

--- a/packages/contracts/deploy/staking.ts
+++ b/packages/contracts/deploy/staking.ts
@@ -1,0 +1,20 @@
+import { DeployFunction } from "hardhat-deploy/types";
+
+const func: DeployFunction = async function (hre) {
+  const { deployer } = await hre.getNamedAccounts();
+  const { deploy, get } = hre.deployments;
+
+  const citizend = await get("Citizend");
+
+  await deploy("Staking", {
+    from: deployer,
+    args: [citizend.address],
+    log: true,
+  });
+};
+
+func.id = "staking";
+func.tags = ["staking"];
+func.dependencies = ["ctnd.token"];
+
+export default func;

--- a/packages/contracts/test/contracts/token/Vesting.ts
+++ b/packages/contracts/test/contracts/token/Vesting.ts
@@ -1,5 +1,4 @@
 import { ethers } from "hardhat";
-import { BigNumber } from "ethers";
 import { expect } from "chai";
 import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import {

--- a/packages/contracts/test/discovery/Staking.ts
+++ b/packages/contracts/test/discovery/Staking.ts
@@ -1,0 +1,97 @@
+import { ethers } from "hardhat";
+import { BigNumber } from "ethers";
+import { expect } from "chai";
+
+import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import {
+  Citizend,
+  Citizend__factory,
+  Staking,
+  Staking__factory,
+} from "../../src/types";
+
+import { increaseTime } from "../timeHelpers";
+
+const { MaxUint256 } = ethers.constants;
+
+describe("Staking", () => {
+  let owner: SignerWithAddress;
+  let alice: SignerWithAddress;
+
+  let staking: Staking;
+  let citizend: Citizend;
+
+  beforeEach(async () => {
+    [owner, alice] = await ethers.getSigners();
+
+    citizend = await new Citizend__factory(owner).deploy(owner.address);
+    staking = await new Staking__factory(owner).deploy(citizend.address);
+
+    await citizend.transfer(alice.address, 1000);
+    await citizend.connect(alice).approve(staking.address, MaxUint256);
+  });
+
+  describe("stake", () => {
+    it("stakes the given amount", async () => {
+      const amount = 100;
+      await staking.connect(alice).stake(amount);
+
+      const stake = await staking.stakes(alice.address);
+
+      expect(stake.actualAmount).to.eq(amount);
+      expect(stake.availableAmount).to.eq(amount);
+    });
+  });
+
+  describe("unbond", () => {
+    it("unbonds the given amount", async () => {
+      const amount = 100;
+      await staking.connect(alice).stake(amount);
+
+      await staking.connect(alice).unbond(amount);
+
+      const stake = await staking.stakes(alice.address);
+      expect(stake.actualAmount).to.eq(100);
+      expect(stake.availableAmount).to.eq(0);
+    });
+  });
+
+  describe("withdraw", () => {
+    it("withdraws the given amount after the unbonding period", async () => {
+      const amount = 100;
+      await staking.connect(alice).stake(amount);
+      await staking.connect(alice).unbond(amount);
+      const unbondingPeriod = await staking.UNBONDING_PERIOD_IN_DAYS();
+      await increaseTime(unbondingPeriod.mul(24 * 60 * 60));
+
+      const action = () => staking.connect(alice).withdraw(amount);
+      await expect(action).to.changeTokenBalance(citizend, alice, amount);
+    });
+
+    it("cannot withdraw before the unbonding period", async () => {
+      const amount = 100;
+      await staking.connect(alice).stake(amount);
+      await staking.connect(alice).unbond(amount);
+
+      await expect(staking.connect(alice).withdraw(amount)).to.be.revertedWith(
+        "not enough unbonded funds"
+      );
+    });
+
+    it("still allows you to withdraw even after failing to withdraw", async () => {
+      const amount = 100;
+      await staking.connect(alice).stake(amount);
+      await staking.connect(alice).unbond(amount);
+
+      await expect(staking.connect(alice).withdraw(amount)).to.be.revertedWith(
+        "not enough unbonded funds"
+      );
+
+      const unbondingPeriod = await staking.UNBONDING_PERIOD_IN_DAYS();
+      await increaseTime(unbondingPeriod.mul(24 * 60 * 60));
+
+      const action = () => staking.connect(alice).withdraw(amount);
+      await expect(action).to.changeTokenBalance(citizend, alice, amount);
+    });
+  });
+});

--- a/packages/contracts/test/discovery/Staking.ts
+++ b/packages/contracts/test/discovery/Staking.ts
@@ -61,8 +61,7 @@ describe("Staking", () => {
       const amount = 100;
       await staking.connect(alice).stake(amount);
       await staking.connect(alice).unbond(amount);
-      const unbondingPeriod = await staking.UNBONDING_PERIOD_IN_DAYS();
-      await increaseTime(unbondingPeriod.mul(24 * 60 * 60));
+      await increaseTime(await staking.UNBONDING_PERIOD());
 
       const action = () => staking.connect(alice).withdraw(amount);
       await expect(action).to.changeTokenBalance(citizend, alice, amount);
@@ -87,8 +86,7 @@ describe("Staking", () => {
         "not enough unbonded funds"
       );
 
-      const unbondingPeriod = await staking.UNBONDING_PERIOD_IN_DAYS();
-      await increaseTime(unbondingPeriod.mul(24 * 60 * 60));
+      await increaseTime(await staking.UNBONDING_PERIOD());
 
       const action = () => staking.connect(alice).withdraw(amount);
       await expect(action).to.changeTokenBalance(citizend, alice, amount);

--- a/packages/contracts/test/discovery/Staking.ts
+++ b/packages/contracts/test/discovery/Staking.ts
@@ -43,6 +43,17 @@ describe("Staking", () => {
     });
   });
 
+  describe("getStake", () => {
+    it("returns the stake of the given address", async () => {
+      const amount = 100;
+      await staking.connect(alice).stake(amount);
+
+      const stake = await staking.connect(alice.address).getStake();
+
+      expect(stake).to.eq(amount);
+    });
+  });
+
   describe("unbond", () => {
     it("unbonds the given amount", async () => {
       const amount = 100;
@@ -53,6 +64,31 @@ describe("Staking", () => {
       const stake = await staking.stakes(alice.address);
       expect(stake.actualAmount).to.eq(100);
       expect(stake.availableAmount).to.eq(0);
+    });
+  });
+
+  describe("rebond", () => {
+    it("rebonds the given amount", async () => {
+      const amount = 100;
+      await staking.connect(alice).stake(amount);
+      await staking.connect(alice).unbond(amount);
+
+      await staking.connect(alice).rebond(50);
+
+      const stake = await staking.stakes(alice.address);
+      expect(stake.actualAmount).to.eq(100);
+      expect(stake.availableAmount).to.eq(50);
+    });
+
+    it("can only rebond the amount that is in the unbonded pool", async () => {
+      const amount = 100;
+      await staking.connect(alice).stake(amount);
+      await staking.connect(alice).unbond(10);
+      await staking.connect(alice).unbond(20);
+
+      await expect(staking.connect(alice).rebond(40)).to.be.revertedWith(
+        "not enough unbonding funds"
+      );
     });
   });
 

--- a/packages/contracts/test/discovery/Staking.ts
+++ b/packages/contracts/test/discovery/Staking.ts
@@ -80,6 +80,19 @@ describe("Staking", () => {
       expect(stake.availableAmount).to.eq(50);
     });
 
+    it("rebonds multiple unbondings at once", async () => {
+      const amount = 100;
+      await staking.connect(alice).stake(amount);
+      await staking.connect(alice).unbond(20);
+      await staking.connect(alice).unbond(10);
+
+      await staking.connect(alice).rebond(25);
+
+      const stake = await staking.stakes(alice.address);
+      expect(stake.actualAmount).to.eq(100);
+      expect(stake.availableAmount).to.eq(95);
+    });
+
     it("can only rebond the amount that is in the unbonded pool", async () => {
       const amount = 100;
       await staking.connect(alice).stake(amount);

--- a/packages/contracts/test/discovery/Staking.ts
+++ b/packages/contracts/test/discovery/Staking.ts
@@ -43,17 +43,6 @@ describe("Staking", () => {
     });
   });
 
-  describe("getStake", () => {
-    it("returns the stake of the given address", async () => {
-      const amount = 100;
-      await staking.connect(alice).stake(amount);
-
-      const stake = await staking.connect(alice.address).getStake();
-
-      expect(stake).to.eq(amount);
-    });
-  });
-
   describe("unbond", () => {
     it("unbonds the given amount", async () => {
       const amount = 100;
@@ -124,6 +113,17 @@ describe("Staking", () => {
       await expect(staking.connect(alice).withdraw(amount)).to.be.revertedWith(
         "not enough unbonded funds"
       );
+    });
+
+    it("can withdraw from multiple unbondings", async () => {
+      const amount = 100;
+      await staking.connect(alice).stake(amount);
+      await staking.connect(alice).unbond(20);
+      await staking.connect(alice).unbond(10);
+      await increaseTime(await staking.UNBONDING_PERIOD());
+
+      const action = () => staking.connect(alice).withdraw(30);
+      await expect(action).to.changeTokenBalance(citizend, alice, 30);
     });
 
     it("still allows you to withdraw even after failing to withdraw", async () => {

--- a/packages/contracts/test/integration/ctnd.sale.ts
+++ b/packages/contracts/test/integration/ctnd.sale.ts
@@ -1,6 +1,4 @@
 import { ethers, deployments, network } from "hardhat";
-import { BigNumber } from "ethers";
-import BN from "bn.js";
 import { expect } from "chai";
 
 import { time } from "@openzeppelin/test-helpers";


### PR DESCRIPTION
Why:

* Token holders should be able to stake their tokens so that they become
  stakers, which will give them certain benefits. Before being able to
  get the tokens back, they need to go through a 28 days unbonding
  period.

This change addresses the need by:

* Keeping an internal list of amount and when they unbond, but to the
  outside treating it as a single amount you're interacting with. Some
  of which you can withdraw, some of which you can't.

  Also added an actual and available amounts, which are how much you've
  staked and how much you still have staked and not unbonding.