### PR TITLE
Add Batch contract interface

### DIFF
--- a/packages/contracts/contracts/discovery/Batch.sol
+++ b/packages/contracts/contracts/discovery/Batch.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity =0.8.12;
+
+import {IBatch} from "./IBatch.sol";
+import {ICommon} from "./ICommon.sol";
+
+contract Batch is IBatch, ICommon {
+    uint256 batchId;
+    /// Ids of the projects
+    uint256[] projectIds;
+    /// number of approved projects in this batch
+    uint256 projectCount;
+    /// number of available slots
+    uint256 slotCount;
+    Period votingPeriod;
+
+    /// user => votes
+    mapping(address => uint256) public userVoteCount;
+
+    /// projectId => votes
+    mapping(uint256 => uint256) public projectVoteCount;
+
+    constructor(
+        uint256 _batchId,
+        uint256[] memory _projectIds,
+        uint256 _slotCount,
+        Period memory _votingPeriod
+    ) {
+        batchId = _batchId;
+        projectIds = _projectIds;
+        projectCount = _projectIds.length;
+        slotCount = _slotCount;
+        votingPeriod = _votingPeriod;
+    }
+}

--- a/packages/contracts/contracts/discovery/IBatch.sol
+++ b/packages/contracts/contracts/discovery/IBatch.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity =0.8.12;
+
+interface IBatch {
+    /// How many votes have been cast by a user on this batch
+    function userVoteCount(address user) external returns (uint256);
+
+    /// How many votes have been cast for a project on this batch
+    function projectVoteCount(uint256 projectId) external returns (uint256);
+}

--- a/packages/contracts/contracts/discovery/ICommon.sol
+++ b/packages/contracts/contracts/discovery/ICommon.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity =0.8.12;
+
+interface ICommon {
+    /// Definition of a time period
+    struct Period {
+        uint256 start;
+        uint256 end;
+    }
+}


### PR DESCRIPTION
Why:
* We decided that each new batch of projects would be handled by a
  separe Batch contract

How:
* Adding an interface, `IBatch.sol`, and a bare-bones implementation of
  the `Batch` contract
* Adding a `ICommon.sol` to share a `Period` struct between the `Batch`
  and the `Controller` contracts
