### PR TITLE
Fixing first run compilation

### DIFF
--- a/.github/workflows/contracts-test.yml
+++ b/.github/workflows/contracts-test.yml
@@ -27,7 +27,7 @@ jobs:
           python-version: "3.x"
 
       - run: yarn install
-      - run: TS_NODE_TRANSPILE_ONLY=1 yarn workspace @discovery-dao/contracts compile
+      - run: yarn workspace @discovery-dao/contracts compile
       - run: yarn workspace @discovery-dao/contracts lint
       - run: yarn workspace @discovery-dao/contracts test
 

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -38,7 +38,7 @@
     "typescript": "^4.6.2"
   },
   "scripts": {
-    "compile": "hardhat compile",
+    "compile": "TS_NODE_TRANSPILE_ONLY=1 hardhat compile",
     "dev": "hardhat node",
     "test": "hardhat test --deploy-fixture",
     "lint": "solhint contracts/**/*.sol && prettier --check . contracts/**/*.sol"


### PR DESCRIPTION
Fixing a chicken&egg issue where the first compilation fails because it depends on typings that are only generated after the run itself

compiling with `TS_NODE_TRANSPILE_ONLY` ensures Typescript won't complain about these missing types during initial compilation