### PR TITLE
Add contracts as context to Web app

### DIFF
--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -41,3 +41,16 @@ To run the project tests (eslint, stylelint and typescript):
 ```sh
 yarn lint
 ```
+
+### Environment variables
+
+## NEXT_PUBLIC_DAO_CONTRACTS_FOLDER
+
+This application will run with the `mandala (staging)` contracts by default.
+In order to bundle the application with other contracts schemas, please use:
+`NEXT_PUBLIC_DAO_CONTRACTS_FOLDER=<folderName> yarn bundle`
+
+Where the `folderName` should be one of the folders in the following folder:
+`../packages/contracts/deployments/`
+
+If running a local blockchain network, use: `NEXT_PUBLIC_DAO_CONTRACTS_FOLDER=localhost yarn start`

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -29,6 +29,7 @@
     ]
   },
   "dependencies": {
+    "@discovery-dao/contracts": "*",
     "@ethersproject/providers": "^5.6.2",
     "@web3-react/core": "^6.1.9",
     "@web3-react/injected-connector": "^6.0.7",

--- a/packages/web/src/context/contracts.tsx
+++ b/packages/web/src/context/contracts.tsx
@@ -1,0 +1,117 @@
+/**
+ * Module dependencies.
+ */
+
+import { Contract, ethers } from 'ethers';
+import {
+  ReactNode,
+  createContext,
+  useContext,
+  useEffect,
+  useState
+} from 'react';
+
+import { Web3Provider } from '@ethersproject/providers';
+import { useWeb3React } from '@web3-react/core';
+
+/**
+ * `Props` type.
+ */
+
+type Props = {
+  children: ReactNode;
+};
+
+/**
+ * `ContractsName` type.
+ */
+
+type ContractsNames = 'aUsd' | 'citizend' | 'fractal' | 'sale1' | 'vesting';
+
+/**
+ * Contracts folder.
+ */
+
+const contractsFolder =
+  process.env.NEXT_PUBLIC_DAO_CONTRACTS_FOLDER || 'mandala';
+
+/**
+ * `ContractsContext` type.
+ */
+
+type ContractsContext =
+  | Record<ContractsNames, Contract>
+  | Record<string, never>;
+
+/**
+ * Web3 contracts context.
+ */
+
+const Web3ContractsContext = createContext<ContractsContext>({});
+
+/**
+ * Export `useContracts` hook.
+ */
+
+export function useContracts(): ContractsContext {
+  return useContext(Web3ContractsContext);
+}
+
+/**
+ * `initializeContracts` hook.
+ */
+
+function initializeContracts(library: Web3Provider): ContractsContext {
+  const contractsConfig = {
+    aUsd: require(`@discovery-dao/contracts/deployments/${contractsFolder}/aUSD.json`),
+    citizend: require(`@discovery-dao/contracts/deployments/${contractsFolder}/Citizend.json`),
+    fractal: require(`@discovery-dao/contracts/deployments/${contractsFolder}/FractalRegistry.json`),
+    sale1: require(`@discovery-dao/contracts/deployments/${contractsFolder}/Sale1.json`),
+    vesting: require(`@discovery-dao/contracts/deployments/${contractsFolder}/Vesting.json`)
+  };
+
+  if (
+    Object.values(contractsConfig).every(({ abi, address }) => !abi || !address)
+  ) {
+    return {};
+  }
+
+  return Object.entries(contractsConfig as ContractsContext).reduce(
+    (contracts, [name, { abi, address }]) => ({
+      ...contracts,
+      [name]: new ethers.Contract(address, abi, library.getSigner(0))
+    }),
+    {}
+  );
+}
+
+/**
+ * Export `ContractsProvider` component.
+ */
+
+export function ContractsProvider({ children }: Props) {
+  const { chainId, library } = useWeb3React<Web3Provider>();
+  const [contracts, setContracts] = useState<ContractsContext>({});
+
+  useEffect(() => {
+    if (!library || !chainId) {
+      return;
+    }
+
+    try {
+      setContracts(initializeContracts(library));
+    } catch (error) {
+      throw new Error(`
+        Contracts Schema for '${contractsFolder}' couldn't be loaded or were wrongly generated.
+        Check the file for '/contracts/deployments/${contractsFolder}/Citizend.json'.
+        Also, check your 'NEXT_PUBLIC_DAO_CONTRACTS_FOLDER' environment variable if the path is not as expected.
+      `);
+    }
+  }, [chainId, library]);
+
+  return (
+    <Web3ContractsContext.Provider value={contracts}>
+      {children}
+    </Web3ContractsContext.Provider>
+  );
+}

--- a/packages/web/src/hooks/use-balance.ts
+++ b/packages/web/src/hooks/use-balance.ts
@@ -1,0 +1,48 @@
+/**
+ * Module dependencies.
+ */
+
+import { Web3Provider } from '@ethersproject/providers';
+import { useCallback, useEffect, useState } from 'react';
+import { useContracts } from 'src/context/contracts';
+import { useWeb3React } from '@web3-react/core';
+
+/**
+ * Export `useBalance` hook.
+ */
+
+export function useBalance() {
+  const [balance, setBalance] = useState<string>('-');
+  const contracts = useContracts();
+  const { account, library } = useWeb3React<Web3Provider>();
+  const getBalance = useCallback(() => {
+    if (!contracts?.citizend) {
+      return;
+    }
+
+    contracts.citizend
+      .balanceOf(account)
+      .then(value => setBalance(value.toString()))
+      .catch
+      // Handle error.
+      ();
+  }, [contracts, account]);
+
+  useEffect(() => {
+    if (!library) {
+      return;
+    }
+
+    getBalance();
+
+    library.on('block', () => {
+      getBalance();
+    });
+
+    return () => {
+      library.removeAllListeners('block');
+    };
+  }, [getBalance, library]);
+
+  return balance;
+}

--- a/packages/web/src/pages/_app.tsx
+++ b/packages/web/src/pages/_app.tsx
@@ -3,6 +3,7 @@
  */
 
 import { AppProps, NextWebVitalsMetric } from 'next/app';
+import { ContractsProvider } from 'src/context/contracts';
 import { ExternalProvider, Web3Provider } from '@ethersproject/providers';
 import { Web3ReactProvider } from '@web3-react/core';
 import GlobalStyle from 'src/components/core/global-style';
@@ -49,7 +50,7 @@ const PageApp = (props: AppProps) => {
   const { Component, pageProps } = props;
 
   return (
-    <Web3ReactProvider getLibrary={getLibrary}>
+    <>
       <Head>
         <meta content={'IE=edge'} httpEquiv={'X-UA-Compatible'} />
 
@@ -76,8 +77,12 @@ const PageApp = (props: AppProps) => {
 
       <GlobalStyle />
 
-      <Component {...pageProps} />
-    </Web3ReactProvider>
+      <Web3ReactProvider getLibrary={getLibrary}>
+        <ContractsProvider>
+          <Component {...pageProps} />
+        </ContractsProvider>
+      </Web3ReactProvider>
+    </>
   );
 };
 

--- a/packages/web/src/pages/index.tsx
+++ b/packages/web/src/pages/index.tsx
@@ -3,29 +3,37 @@
  */
 
 import { Web3Provider } from '@ethersproject/providers';
+import { useBalance } from 'src/hooks/use-balance';
 import { useWeb3React } from '@web3-react/core';
 import Metatags from 'src/components/core/metatags';
 import React from 'react';
 import useWalletConnect from 'src/hooks/use-wallet-connect';
 
 /**
- * `ConnectWallet` component.
+ * `Home` page.
  */
 
-const ConnectWallet = () => {
+function Home() {
   const { account, active } = useWeb3React<Web3Provider>();
   const { connectStatus, onConnect, onDisconnect } = useWalletConnect();
+  const balance = useBalance();
 
   return (
-    <div>
+    <>
+      <Metatags />
+
       <div>{`Account: ${account ?? '-'}`}</div>
 
       <div>{`Connection Status: ${active ? '🟢' : '🔴'}`}</div>
 
       {active ? (
-        <button onClick={onDisconnect} type={'button'}>
-          {'Disconnect'}
-        </button>
+        <>
+          <div>{`Balance: ${balance}`}</div>
+
+          <button onClick={onDisconnect} type={'button'}>
+            {'Disconnect'}
+          </button>
+        </>
       ) : (
         <>
           <button
@@ -53,20 +61,6 @@ const ConnectWallet = () => {
           <div>{'Sign the message in your wallet to continue'}</div>
         </div>
       )}
-    </div>
-  );
-};
-
-/**
- * `Home` page.
- */
-
-function Home() {
-  return (
-    <>
-      <Metatags />
-
-      <ConnectWallet />
     </>
   );
 }

--- a/packages/web/src/types/global.d.ts
+++ b/packages/web/src/types/global.d.ts
@@ -1,2 +1,3 @@
 declare module '*.svg';
 declare module '*.css';
+declare module '*.json';


### PR DESCRIPTION
This PR adds the contracts that are provided by the `Contracts` part of the project under `/contracts/deployments/localhost/<contractName>.json`.
This injects all contracts into the app by using context once the user is connected with a wallet.

It also provides the user balance on the `Sale1` contract.