### PR TITLE
Allows approving a Project to be included in a Batch

### DIFF
--- a/packages/contracts/contracts/discovery/Controller.sol
+++ b/packages/contracts/contracts/discovery/Controller.sol
@@ -24,6 +24,8 @@ contract Controller is IController, AccessControl {
         keccak256("PROJECT_MANAGER_ROLE");
     bytes32 public constant BATCH_MANAGER_ROLE =
         keccak256("BATCH_MANAGER_ROLE");
+    bytes32 public constant LEGAL_MANAGER_ROLE =
+        keccak256("LEGAL_MANAGER_ROLE");
 
     //
     // State
@@ -42,6 +44,7 @@ contract Controller is IController, AccessControl {
         _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
         _grantRole(PROJECT_MANAGER_ROLE, msg.sender);
         _grantRole(BATCH_MANAGER_ROLE, msg.sender);
+        _grantRole(LEGAL_MANAGER_ROLE, msg.sender);
     }
 
     //
@@ -116,6 +119,15 @@ contract Controller is IController, AccessControl {
 
     // Checks if a given account has the BATCH_MANAGER_ROLE role
     function hasBatchManagerRole(address _account)
+        external
+        view
+        returns (bool)
+    {
+        return hasRole(BATCH_MANAGER_ROLE, _account);
+    }
+
+    // Checks if a given account has the LEGAL_MANAGER_ROLE role
+    function hasLegalManagerRole(address _account)
         external
         view
         returns (bool)

--- a/packages/contracts/contracts/discovery/Project.sol
+++ b/packages/contracts/contracts/discovery/Project.sol
@@ -39,6 +39,9 @@ contract Project is IProject, ERC165 {
     // has the project been approved by a Citizend manager
     bool public override(IProject) approvedByManager;
 
+    // has the project been approved by the legal team
+    bool public override(IProject) approvedByLegal;
+
     constructor(
         string memory _description,
         address _token,
@@ -65,7 +68,11 @@ contract Project is IProject, ERC165 {
             IController(controller).hasProjectManagerRole(msg.sender),
             "not a project manager"
         );
+        _;
+    }
 
+    modifier onlyBatch() {
+        IController(controller).isProjectInBatch(address(this), msg.sender);
         _;
     }
 
@@ -83,7 +90,20 @@ contract Project is IProject, ERC165 {
         override(IProject)
         onlyManager(msg.sender)
     {
+        require(approvedByManager == false, "already approved by manager");
+
         approvedByManager = true;
+    }
+
+    /// @inheritdoc IProject
+    function approveByLegal()
+        public
+        override(IProject)
+        onlyManager(msg.sender)
+    {
+        require(approvedByLegal == false, "already approved by legal");
+
+        approvedByLegal = true;
     }
 
     /// @inheritdoc IProject
@@ -100,7 +120,7 @@ contract Project is IProject, ERC165 {
         override(IProject)
         returns (bool)
     {
-        return hasTokens() && approvedByManager;
+        return hasTokens() && approvedByManager && approvedByLegal;
     }
 
     //

--- a/packages/contracts/contracts/discovery/Project.sol
+++ b/packages/contracts/contracts/discovery/Project.sol
@@ -71,6 +71,14 @@ contract Project is IProject, ERC165 {
         _;
     }
 
+    modifier onlyLegal(address _account) {
+        require(
+            IController(controller).hasLegalManagerRole(msg.sender),
+            "not a legal manager"
+        );
+        _;
+    }
+
     modifier onlyBatch() {
         IController(controller).isProjectInBatch(address(this), msg.sender);
         _;
@@ -96,11 +104,7 @@ contract Project is IProject, ERC165 {
     }
 
     /// @inheritdoc IProject
-    function approveByLegal()
-        public
-        override(IProject)
-        onlyManager(msg.sender)
-    {
+    function approveByLegal() public override(IProject) onlyLegal(msg.sender) {
         require(approvedByLegal == false, "already approved by legal");
 
         approvedByLegal = true;

--- a/packages/contracts/contracts/discovery/Project.sol
+++ b/packages/contracts/contracts/discovery/Project.sol
@@ -79,11 +79,6 @@ contract Project is IProject, ERC165 {
         _;
     }
 
-    modifier onlyBatch() {
-        IController(controller).isProjectInBatch(address(this), msg.sender);
-        _;
-    }
-
     function invest(uint256 _peoplesAmount, uint256 _stakersAmount) external {
         revert("not yet implemented");
     }

--- a/packages/contracts/contracts/discovery/Project.sol
+++ b/packages/contracts/contracts/discovery/Project.sol
@@ -93,7 +93,7 @@ contract Project is IProject, ERC165 {
         override(IProject)
         onlyManager(msg.sender)
     {
-        require(approvedByManager == false, "already approved by manager");
+        require(!approvedByManager, "already approved by manager");
 
         approvedByManager = true;
     }

--- a/packages/contracts/contracts/discovery/Project.sol
+++ b/packages/contracts/contracts/discovery/Project.sol
@@ -100,7 +100,7 @@ contract Project is IProject, ERC165 {
 
     /// @inheritdoc IProject
     function approveByLegal() public override(IProject) onlyLegal(msg.sender) {
-        require(approvedByLegal == false, "already approved by legal");
+        require(!approvedByLegal, "already approved by legal");
 
         approvedByLegal = true;
     }

--- a/packages/contracts/contracts/discovery/interfaces/IController.sol
+++ b/packages/contracts/contracts/discovery/interfaces/IController.sol
@@ -15,6 +15,14 @@ interface IController {
         view
         returns (bool);
 
+    // Checks if a given account has the LEGAL_MANAGER_ROLE role
+    /// @param _account Account to check
+    /// @return true if account is a legal manager
+    function hasLegalManagerRole(address _account)
+        external
+        view
+        returns (bool);
+
     /// @param _project address of the project
     /// @return Batch address
     function getBatchForProject(address _project)

--- a/packages/contracts/contracts/discovery/interfaces/IProject.sol
+++ b/packages/contracts/contracts/discovery/interfaces/IProject.sol
@@ -8,6 +8,12 @@ interface IProject {
     /// One of the criteria for listing: has the project been approved by a project manager?
     function approvedByManager() external view returns (bool);
 
+    /// Approval function from the legal team
+    function approveByLegal() external;
+
+    /// One of the criteria for listing: has the project been approved by the legal team?
+    function approvedByLegal() external view returns (bool);
+
     /// One of the criteria for listing: does the project contract hold the sale
     /// supply already?
     function hasTokens() external view returns (bool);

--- a/packages/contracts/test/contracts/discovery/Controller.ts
+++ b/packages/contracts/test/contracts/discovery/Controller.ts
@@ -118,7 +118,8 @@ describe("Controller", () => {
       expect(await project.approvedByManager()).to.equal(true);
       expect(await project.isReadyForListing()).to.equal(true);
 
-      await expect(controller.createBatch([projectAddress], 1)).to.not.be.reverted;
+      await expect(controller.createBatch([projectAddress], 1)).to.not.be
+        .reverted;
     });
 
     it("reverts if a project is not approved", async () => {
@@ -132,7 +133,9 @@ describe("Controller", () => {
       const event = await findEvent(tx, "ProjectRegistered");
       const projectAddress = event?.args?.project;
 
-      await expect(controller.createBatch([projectAddress], 1)).to.be.revertedWith("project not ready");
+      await expect(
+        controller.createBatch([projectAddress], 1)
+      ).to.be.revertedWith("project not ready");
     });
 
     it("reverts if a project is already included in a different batch", async () => {
@@ -159,8 +162,11 @@ describe("Controller", () => {
       expect(await project.approvedByManager()).to.equal(true);
       expect(await project.isReadyForListing()).to.equal(true);
 
-      await expect(controller.createBatch([projectAddress], 1)).to.not.be.reverted;
-      await expect(controller.createBatch([projectAddress], 1)).to.be.revertedWith("already in a batch");
+      await expect(controller.createBatch([projectAddress], 1)).to.not.be
+        .reverted;
+      await expect(
+        controller.createBatch([projectAddress], 1)
+      ).to.be.revertedWith("already in a batch");
     });
   });
 });


### PR DESCRIPTION
Why:
* The Controller contract is responsible for managing the Projects and
  creating Batches

How:
* Adding `approveByLegal` and `approveByManager` to
  the Project contract to allow the approval of a project
* Adding tests to the `createBatch` function of the Controller
