### PR TITLE
Replace CODEOWNERS with Reviewpad Action

### DIFF
--- a/.github/workflows/reviewpad.yml
+++ b/.github/workflows/reviewpad.yml
@@ -1,0 +1,10 @@
+name: Reviewpad
+on:
+  pull_request
+
+jobs:
+  reviewpad-action:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Running reviewpad action
+        uses: reviewpad/action@v0.0.2

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,0 @@
-# By default, notify naps62 for all reviews
-* @naps62
-
-# notify the smart contracts team for all contract reviews
-packages/contracts @naps62 @zamith @DavideSilva

--- a/revy.yml
+++ b/revy.yml
@@ -1,0 +1,73 @@
+apiVersion: reviewpad.com/v0.0.2
+
+mode: silent
+
+labels:
+  small:
+    description: small changes
+    # color is the hexadecimal color code for the label, without the leading #.
+    color: "294b69"
+  medium:
+    description: small changes
+    color: "a8c3f7"
+  large:
+    description: large changes
+    color: "8a2138"
+
+rules:
+  isSmall:
+    kind: patch
+    description: small pull request
+    spec: $size() <= 90
+
+  isMedium:
+    kind: patch
+    description: medium-sized pull request
+    spec: $size() > 90 && $size() <= 300
+
+  isLarge:
+    kind: patch
+    description: large-sized pull request
+    spec: $size() > 300
+  
+  tautology:
+    kind: patch
+    description: true by default
+    spec: "true"
+
+  touchesContracts:
+    kind: patch
+    description: touches package contracts
+    spec: $hasFilePattern("packages/contracts/**")
+
+protectionGates:
+  - name: assign-naps-for-everything
+    description: By default, assign naps for every pull request
+    patchRules:
+      - rule: tautology
+    actions:
+      - $assignReviewer(["naps62"])
+  - name: assign-reviewers-contracts
+    description: Assign team to review the smart contracts
+    patchRules:
+      - rule: touchesContracts
+    actions:
+      - $assignReviewer(["naps62", "zamith", "DavideSilva"])
+  - name: label-small-pull-request
+    description: Label small pull requests with size
+    patchRules:
+      - rule: isSmall
+    actions:
+      - $addLabel("small")
+  - name: label-medium-pull-request
+    description: Label medium pull requests with size
+    patchRules:
+      - rule: isMedium
+    actions:
+      - $addLabel("medium")
+  - name: label-large-pull-request
+    description: Label large pull requests with size
+    patchRules:
+      - rule: isLarge
+    actions:
+      - $addLabel("large")

--- a/revy.yml
+++ b/revy.yml
@@ -29,11 +29,6 @@ rules:
     kind: patch
     description: large-sized pull request
     spec: $size() > 300
-  
-  tautology:
-    kind: patch
-    description: true by default
-    spec: "true"
 
   touchesContracts:
     kind: patch
@@ -41,12 +36,6 @@ rules:
     spec: $hasFilePattern("packages/contracts/**")
 
 protectionGates:
-  - name: assign-naps-for-everything
-    description: By default, assign naps for every pull request
-    patchRules:
-      - rule: tautology
-    actions:
-      - $assignReviewer(["naps62"])
   - name: assign-reviewers-contracts
     description: Assign team to review the smart contracts
     patchRules:


### PR DESCRIPTION
This pull request introduces the following changes:

- Use Reviewpad action to:
  1. Automatically label the PR based on their size.
  2. Assign reviewers.
- Remove CODEOWNERS