### PR TITLE
Fixing mocha configs for VS Code

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,9 @@
       "**/@typechain/**",
       "**/@polkadot/**",
       "**/typechain/**",
-      "**/typescript",
-      "**/ts-node",
+      "**/typescript/**",
+      "**/ts-node/**",
+      "**/mocha/**",
       "@typescript-eslint/**"
     ]
   },

--- a/packages/contracts/.gitignore
+++ b/packages/contracts/.gitignore
@@ -3,5 +3,4 @@ cache
 node_modules
 src/types
 deployments/localhost
-.vscode
 *.csv

--- a/packages/contracts/.mocharc.json
+++ b/packages/contracts/.mocharc.json
@@ -1,4 +1,4 @@
 {
-  "require": "ts-node/register",
+  "require": "ts-node/register/files",
   "timeout": 40000
 }

--- a/packages/contracts/.vscode/launch.json
+++ b/packages/contracts/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "hardhat test",
+      "skipFiles": ["<node_internals>/**"],
+      "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/hardhat",
+      "args": ["test"],
+      "cwd": "${workspaceRoot}"
+    }
+  ]
+}


### PR DESCRIPTION
The configs on this PR are what allows me to run tests from VS Code:
![image](https://user-images.githubusercontent.com/283819/163569495-aa204cf4-4bcb-4204-bef8-02a54ded7dde.png)

I'll need someone to test that this still works under vim, though, by running the following:
```
rm -rf node_modules packages/contracts/node_modules
yarn install
```
and then testing their test setup