### PR TITLE
Implements RisingTide for Pools 

### DIFF
--- a/packages/contracts/contracts/discovery/Project.sol
+++ b/packages/contracts/contracts/discovery/Project.sol
@@ -55,8 +55,11 @@ contract Project is IProject, ERC165 {
         saleSupply = _saleSupply;
         rate = _rate;
 
-        stakersPool = address(new StakersPool());
-        peoplesPool = address(new PeoplesPool());
+        uint256 stakersPoolSupply = saleSupply / 2;
+        uint256 peoplesPoolSupply = saleSupply - stakersPoolSupply;
+
+        stakersPool = address(new StakersPool(stakersPoolSupply));
+        peoplesPool = address(new PeoplesPool(peoplesPoolSupply));
     }
 
     //

--- a/packages/contracts/contracts/discovery/interfaces/IPool.sol
+++ b/packages/contracts/contracts/discovery/interfaces/IPool.sol
@@ -3,7 +3,16 @@ pragma solidity =0.8.12;
 
 interface IPool {
     /// Similar to Sale.buy
-    function buy(uint256 _amount) external;
+    function invest(address _investor, uint256 _amount) external;
+
+    /**
+     * Sets the individual cap for investors, which will then be used when
+     * claiming or refunding. Only callable by the cap validator role.
+     *
+     * @param _cap The cap per investor to be set, specified in the
+     * project's token
+     */
+    function setIndividualCap(uint256 _cap) external;
 
     /// Similar to Sale.refund
     function refund(address _to) external;

--- a/packages/contracts/contracts/discovery/pools/PeoplesPool.sol
+++ b/packages/contracts/contracts/discovery/pools/PeoplesPool.sol
@@ -3,4 +3,6 @@ pragma solidity =0.8.12;
 
 import {Pool} from "./Pool.sol";
 
-contract PeoplesPool is Pool {}
+contract PeoplesPool is Pool {
+    constructor(uint256 _saleSupply) Pool(_saleSupply) {}
+}

--- a/packages/contracts/contracts/discovery/pools/Pool.sol
+++ b/packages/contracts/contracts/discovery/pools/Pool.sol
@@ -2,19 +2,37 @@
 pragma solidity =0.8.12;
 
 import {IPool} from "../interfaces/IPool.sol";
+import {RisingTide} from "../../RisingTide/RisingTide.sol";
+
+import "hardhat/console.sol";
 
 /**
  * TODO users should be able to `buy` into the pool, as long as they meet the conditions
  * (stakerspool is for CTND stakers, peoplespool is for those who have already voted for the project)
  *
- * TODO `buy` is for the Project to called from the project only
+ * TODO `buy` is for the Project to be called from the project only
  * TODO other than these requirements, the rest should be very similar to the CTND Sale contract
  */
-abstract contract Pool is IPool {
+abstract contract Pool is IPool, RisingTide {
     address project;
 
-    constructor() {
+    /// total unique investors
+    uint256 public _investorCount;
+
+    mapping(address => uint256) investorBalances;
+
+    /// incrementing index => investor address
+    mapping(uint256 => address) investorByIndex;
+
+    /// How many tokens have been allocated, before cap calculation
+    uint256 public totalUncappedAllocations;
+
+    // Total supply of the project's token up for sale
+    uint256 public immutable saleSupply;
+
+    constructor(uint256 _saleSupply) {
         project = msg.sender;
+        saleSupply = _saleSupply;
     }
 
     modifier onlyProject() {
@@ -27,8 +45,22 @@ abstract contract Pool is IPool {
     //
 
     /// @inheritdoc IPool
-    function buy(uint256 _amount) external override(IPool) onlyProject {
-        revert("not yet implemented");
+    function invest(address _investor, uint256 _amount)
+        external
+        override(IPool)
+        onlyProject
+    {
+        if (investorBalances[_investor] == 0) {
+            investorByIndex[_investorCount] = _investor;
+            _investorCount++;
+        }
+
+        investorBalances[_investor] += _amount;
+        totalUncappedAllocations += _amount;
+    }
+
+    function setIndividualCap(uint256 _cap) external {
+        _risingTide_setCap(_cap);
     }
 
     /// @inheritdoc IPool
@@ -64,5 +96,51 @@ abstract contract Pool is IPool {
         returns (uint256 amount)
     {
         revert("not yet implemented");
+    }
+
+    //
+    // RisingTide
+    //
+
+    /// @inheritdoc RisingTide
+    function investorCount()
+        public
+        view
+        override(RisingTide)
+        returns (uint256)
+    {
+        return _investorCount;
+    }
+
+    /// @inheritdoc RisingTide
+    function investorAmountAt(uint256 i)
+        public
+        view
+        override(RisingTide)
+        returns (uint256)
+    {
+        address addr = investorByIndex[i];
+
+        return investorBalances[addr];
+    }
+
+    /// @inheritdoc RisingTide
+    function risingTide_totalAllocatedUncapped()
+        public
+        view
+        override(RisingTide)
+        returns (uint256)
+    {
+        return totalUncappedAllocations;
+    }
+
+    /// @inheritdoc RisingTide
+    function risingTide_totalCap()
+        public
+        view
+        override(RisingTide)
+        returns (uint256)
+    {
+        return saleSupply;
     }
 }

--- a/packages/contracts/contracts/discovery/pools/TestPool.sol
+++ b/packages/contracts/contracts/discovery/pools/TestPool.sol
@@ -3,6 +3,6 @@ pragma solidity =0.8.12;
 
 import {Pool} from "./Pool.sol";
 
-contract StakersPool is Pool {
+contract TestPool is Pool {
     constructor(uint256 _saleSupply) Pool(_saleSupply) {}
 }

--- a/packages/contracts/test/contracts/discovery/pool/Pool.ts
+++ b/packages/contracts/test/contracts/discovery/pool/Pool.ts
@@ -2,21 +2,21 @@ import { ethers, deployments } from "hardhat";
 import { expect } from "chai";
 
 import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
-import { PeoplesPool, PeoplesPool__factory } from "../../../../src/types";
+import { TestPool, TestPool__factory } from "../../../../src/types";
 
 const { parseUnits } = ethers.utils;
 
-describe("PeoplesPool", () => {
+describe("Pool", () => {
   let owner: SignerWithAddress;
   let alice: SignerWithAddress;
   let bob: SignerWithAddress;
 
-  let pool: PeoplesPool;
+  let pool: TestPool;
 
   beforeEach(async () => {
     [owner, alice, bob] = await ethers.getSigners();
 
-    const pool = new PeoplesPool__factory(owner).deploy();
+    pool = await new TestPool__factory(owner).deploy(parseUnits("10000"));
   });
 
   describe("constructor", () => {
@@ -34,7 +34,23 @@ describe("PeoplesPool", () => {
   });
 
   describe("setIndividualCap", () => {
-    it("TODO similar tests from Sale.sol");
+    it("allows me to set the cap after investment period is over", async () => {
+      await pool.invest(alice.address, 100);
+
+      await pool.setIndividualCap(100, { gasLimit: 10000000 });
+
+      expect(await pool.individualCap()).to.equal(100);
+      expect(await pool.risingTide_isValidCap()).to.equal(true);
+    });
+
+    it("fails to validate the cap for the wrong value", async () => {
+      await pool.invest(alice.address, 100);
+
+      await pool.setIndividualCap(50, { gasLimit: 10000000 });
+
+      expect(await pool.individualCap()).to.equal(50);
+      expect(await pool.risingTide_isValidCap()).to.equal(false);
+    });
   });
 
   describe("refund", () => {


### PR DESCRIPTION
Why:

* The RisingTide mechanism will also be applied to both Project's Pools,
  after the investment period on a batch has ended.

This change addresses the need by:

* Ensuring Pool implements the RisingTide contract, while creating a
  TestPool contract that we can use to test the behavior in Pool, since
  it's abstract.