### PR TITLE
Improvements to Batch and Controller communication

### DIFF
--- a/packages/contracts/contracts/discovery/Batch.sol
+++ b/packages/contracts/contracts/discovery/Batch.sol
@@ -63,6 +63,10 @@ contract Batch is IBatch, ICommon, ProjectVoting {
                 "project must be an IProject"
             );
         }
+        require(
+            msg.sender.supportsInterface(type(IController).interfaceId),
+            "sender must be an IController"
+        );
         controller = msg.sender;
         projects = _projects;
         slotCount = _slotCount;

--- a/packages/contracts/contracts/discovery/Batch.sol
+++ b/packages/contracts/contracts/discovery/Batch.sol
@@ -5,6 +5,7 @@ import {ERC165Checker} from "@openzeppelin/contracts/utils/introspection/ERC165C
 
 import {ICommon} from "./interfaces/ICommon.sol";
 import {IProject} from "./interfaces/IProject.sol";
+import {IController} from "./interfaces/IController.sol";
 import {IBatch} from "./interfaces/IBatch.sol";
 import {IStaking} from "./interfaces/IStaking.sol";
 import {ProjectVoting} from "./ProjectVoting.sol";
@@ -20,6 +21,9 @@ contract Batch is IBatch, ICommon, ProjectVoting {
 
     /// Period for which the batch is open for voting
     Period public votingPeriod;
+
+    /// Timestamp at which the batch is closed for investment
+    uint256 public investmentEnd;
 
     /// Address for the controller contract
     address public immutable controller;
@@ -112,15 +116,17 @@ contract Batch is IBatch, ICommon, ProjectVoting {
         return 0;
     }
 
-    function hasVotedForProject(address _user, address _project)
-        external
-        view
-        returns (bool)
-    {
-        return userHasVotedForProject[_project][_user];
+    function inInvestmentPeriod() external returns (bool) {
+        return
+            votingPeriod.start >= block.timestamp &&
+            investmentEnd <= block.timestamp;
     }
 
-    function setVotingPeriod(uint256 start, uint256 end) external {
+    function setVotingPeriod(
+        uint256 start,
+        uint256 end,
+        uint256 extraInvestmentDuration
+    ) external {
         require(start >= block.timestamp, "start must be in the future");
         require(start < end, "start must be before end");
         require(
@@ -131,6 +137,7 @@ contract Batch is IBatch, ICommon, ProjectVoting {
         singleSlotDuration =
             (votingPeriod.end - votingPeriod.start) /
             slotCount;
+        investmentEnd = votingPeriod.end + extraInvestmentDuration;
     }
 
     function vote(address projectAddress)
@@ -138,6 +145,11 @@ contract Batch is IBatch, ICommon, ProjectVoting {
         votingPeriodIsSet
         inVotingPeriod
     {
+        require(
+            IController(controller).canVote(msg.sender),
+            "not allowed to vote"
+        );
+
         _vote(projectAddress);
     }
 

--- a/packages/contracts/contracts/discovery/Controller.sol
+++ b/packages/contracts/contracts/discovery/Controller.sol
@@ -2,6 +2,8 @@
 pragma solidity =0.8.12;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 import {IController} from "./interfaces/IController.sol";
@@ -12,9 +14,7 @@ import {Project} from "./Project.sol";
 import {Batch} from "./Batch.sol";
 import {FractalRegistry} from "../fractal_registry/FractalRegistry.sol";
 
-import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
-
-contract Controller is IController, AccessControl {
+contract Controller is IController, ERC165, AccessControl {
     using SafeERC20 for IERC20;
 
     //
@@ -225,5 +225,21 @@ contract Controller is IController, AccessControl {
         returns (address)
     {
         return projectsToBatches[_project];
+    }
+
+    //
+    // ERC165
+    //
+
+    /// @inheritdoc ERC165
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        override(ERC165, AccessControl)
+        returns (bool)
+    {
+        return
+            interfaceId == type(IController).interfaceId ||
+            super.supportsInterface(interfaceId);
     }
 }

--- a/packages/contracts/contracts/discovery/Controller.sol
+++ b/packages/contracts/contracts/discovery/Controller.sol
@@ -150,16 +150,26 @@ contract Controller is IController, AccessControl {
         return
             _hasKYC(_user) &&
             _belongsToDAO(_user) &&
-            batch.hasVotedForProject(_user, _project);
+            batch.userHasVotedForProject(_project, _user);
+    }
+
+    function canVote(address _user)
+        external
+        view
+        override(IController)
+        returns (bool)
+    {
+        return _hasKYC(_user) && _belongsToDAO(_user);
     }
 
     /// @inheritdoc IController
     function setBatchVotingPeriod(
         address batch,
         uint256 start,
-        uint256 end
+        uint256 end,
+        uint256 extraInvestmentDuration
     ) external override(IController) onlyRole(BATCH_MANAGER_ROLE) {
-        Batch(batch).setVotingPeriod(start, end);
+        Batch(batch).setVotingPeriod(start, end, extraInvestmentDuration);
     }
 
     function _hasKYC(address _user) internal view returns (bool) {

--- a/packages/contracts/contracts/discovery/TestProjectVoting.sol
+++ b/packages/contracts/contracts/discovery/TestProjectVoting.sol
@@ -49,7 +49,7 @@ contract TestProjectVoting is ProjectVoting {
 
     function projectVoting_initialBonus()
         public
-        view
+        pure
         override(ProjectVoting)
         returns (int256)
     {
@@ -58,7 +58,7 @@ contract TestProjectVoting is ProjectVoting {
 
     function projectVoting_finalBonus()
         public
-        view
+        pure
         override(ProjectVoting)
         returns (int256)
     {

--- a/packages/contracts/contracts/discovery/interfaces/IController.sol
+++ b/packages/contracts/contracts/discovery/interfaces/IController.sol
@@ -18,10 +18,7 @@ interface IController {
     // Checks if a given account has the LEGAL_MANAGER_ROLE role
     /// @param _account Account to check
     /// @return true if account is a legal manager
-    function hasLegalManagerRole(address _account)
-        external
-        view
-        returns (bool);
+    function hasLegalManagerRole(address _account) external view returns (bool);
 
     /// @param _project address of the project
     /// @return Batch address
@@ -61,10 +58,14 @@ interface IController {
         view
         returns (bool);
 
+    /// Checks if a user can vote
+    function canVote(address _user) external view returns (bool);
+
     /// Sets the voting period for a Batch
     function setBatchVotingPeriod(
         address batch,
         uint256 start,
-        uint256 end
+        uint256 end,
+        uint256 extraInvestmentDuration
     ) external;
 }

--- a/packages/contracts/test/contracts/discovery/Controller.ts
+++ b/packages/contracts/test/contracts/discovery/Controller.ts
@@ -1,4 +1,4 @@
-import { ethers, deployments } from "hardhat";
+import { ethers } from "hardhat";
 import { expect } from "chai";
 
 import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
@@ -19,8 +19,7 @@ import {
   Staking__factory,
 } from "../../../src/types";
 
-import { findEvent } from "../../shared/utils";
-import { goToTime, currentTimestamp } from "../../timeHelpers";
+import { registerProject, makeProjectReady, setUpBatch } from "./helpers";
 
 const { parseUnits, formatBytes32String } = ethers.utils;
 const { MaxUint256 } = ethers.constants;
@@ -75,7 +74,7 @@ describe("Controller", () => {
       await citizend.transfer(alice.address, 1000);
       await citizend.connect(alice).approve(staking.address, MaxUint256);
       await staking.connect(alice).stake(100);
-      project = await registerProject(owner, projectToken);
+      project = await registerProject(owner, projectToken, controller);
 
       expect(await controller.canInvestInStakersPool(alice.address)).to.be.true;
     });
@@ -84,7 +83,7 @@ describe("Controller", () => {
       await citizend.transfer(alice.address, 1000);
       await citizend.connect(alice).approve(staking.address, MaxUint256);
       await staking.connect(alice).stake(100);
-      project = await registerProject(owner, projectToken);
+      project = await registerProject(owner, projectToken, controller);
 
       expect(await controller.canInvestInStakersPool(alice.address)).to.be
         .false;
@@ -92,7 +91,7 @@ describe("Controller", () => {
 
     it("is false if the user does not belong to the DAO", async () => {
       await registry.addUserAddress(alice.address, formatBytes32String("id1"));
-      project = await registerProject(owner, projectToken);
+      project = await registerProject(owner, projectToken, controller);
 
       expect(await controller.canInvestInStakersPool(alice.address)).to.be
         .false;
@@ -101,7 +100,7 @@ describe("Controller", () => {
     it("is false if the user does not have staked tokens", async () => {
       await registry.addUserAddress(alice.address, formatBytes32String("id1"));
       await citizend.transfer(alice.address, 1000);
-      project = await registerProject(owner, projectToken);
+      project = await registerProject(owner, projectToken, controller);
 
       expect(await controller.canInvestInStakersPool(alice.address)).to.be
         .false;
@@ -112,9 +111,9 @@ describe("Controller", () => {
     it("is true if the user meets all the requirements", async () => {
       await registry.addUserAddress(alice.address, formatBytes32String("id1"));
       await citizend.transfer(alice.address, 1000);
-      project = await registerProject(owner, projectToken);
+      project = await registerProject(owner, projectToken, controller);
       await makeProjectReady(project, projectToken);
-      const batch: Batch = await setUpBatch(controller, project, owner);
+      const batch: Batch = await setUpBatch(controller, [project], owner);
       await batch.connect(alice).vote(project.address);
 
       expect(
@@ -124,10 +123,9 @@ describe("Controller", () => {
 
     it("is false if the user does not have the KYC", async () => {
       await citizend.transfer(alice.address, 1000);
-      project = await registerProject(owner, projectToken);
+      project = await registerProject(owner, projectToken, controller);
       await makeProjectReady(project, projectToken);
-      const batch: Batch = await setUpBatch(controller, project, owner);
-      await batch.connect(alice).vote(project.address);
+      const batch: Batch = await setUpBatch(controller, [project], owner);
 
       expect(
         await controller.canInvestInPeoplesPool(project.address, alice.address)
@@ -136,10 +134,9 @@ describe("Controller", () => {
 
     it("is false if the user does not belong to the DAO", async () => {
       await registry.addUserAddress(alice.address, formatBytes32String("id1"));
-      project = await registerProject(owner, projectToken);
+      project = await registerProject(owner, projectToken, controller);
       await makeProjectReady(project, projectToken);
-      const batch: Batch = await setUpBatch(controller, project, owner);
-      await batch.connect(alice).vote(project.address);
+      const batch: Batch = await setUpBatch(controller, [project], owner);
 
       expect(
         await controller.canInvestInPeoplesPool(project.address, alice.address)
@@ -149,9 +146,9 @@ describe("Controller", () => {
     it("is false if the user hasn't voted in the project", async () => {
       await citizend.transfer(alice.address, 1000);
       await registry.addUserAddress(alice.address, formatBytes32String("id1"));
-      project = await registerProject(owner, projectToken);
+      project = await registerProject(owner, projectToken, controller);
       await makeProjectReady(project, projectToken);
-      await setUpBatch(controller, project, owner);
+      await setUpBatch(controller, [project], owner);
 
       expect(
         await controller.canInvestInPeoplesPool(project.address, alice.address)
@@ -161,7 +158,7 @@ describe("Controller", () => {
 
   describe("registerProject", () => {
     it("registers a project", async () => {
-      project = await registerProject(owner, projectToken);
+      project = await registerProject(owner, projectToken, controller);
 
       expect(await project.description()).to.eq("My Project");
       expect(await project.token()).to.eq(projectToken.address);
@@ -187,7 +184,7 @@ describe("Controller", () => {
 
   describe("createBatch", () => {
     it("creates a batch", async () => {
-      project = await registerProject(owner, projectToken);
+      project = await registerProject(owner, projectToken, controller);
       await makeProjectReady(project, projectToken);
 
       expect(await project.approvedByLegal()).to.equal(true);
@@ -199,7 +196,7 @@ describe("Controller", () => {
     });
 
     it("reverts if a project is not approved", async () => {
-      project = await registerProject(owner, projectToken);
+      project = await registerProject(owner, projectToken, controller);
 
       await expect(
         controller.createBatch([project.address], 1)
@@ -207,7 +204,7 @@ describe("Controller", () => {
     });
 
     it("reverts if a project is already included in a different batch", async () => {
-      project = await registerProject(owner, projectToken);
+      project = await registerProject(owner, projectToken, controller);
       await makeProjectReady(project, projectToken);
 
       expect(await project.approvedByLegal()).to.equal(true);
@@ -221,48 +218,4 @@ describe("Controller", () => {
       ).to.be.revertedWith("already in a batch");
     });
   });
-
-  async function registerProject(
-    owner: SignerWithAddress,
-    projectToken: MockERC20
-  ): Promise<Project> {
-    const tx = await controller.registerProject(
-      "My Project",
-      projectToken.address,
-      parseUnits("1000"),
-      parseUnits("2")
-    );
-
-    const event = await findEvent(tx, "ProjectRegistered");
-    const projectAddress = event?.args?.project;
-
-    return Project__factory.connect(projectAddress, owner);
-  }
-
-  async function makeProjectReady(project: Project, projectToken: MockERC20) {
-    await projectToken.transfer(project.address, parseUnits("1000"));
-    await project.approveByManager();
-    await project.approveByLegal();
-  }
-
-  async function setUpBatch(
-    controller: Controller,
-    project: Project,
-    owner: SignerWithAddress
-  ): Promise<Batch> {
-    await controller.createBatch([project.address], 1);
-    const batch: Batch = await Batch__factory.connect(
-      await controller.projectsToBatches(project.address),
-      owner
-    );
-    const startTime: number = (await currentTimestamp()) + 100;
-    await controller.setBatchVotingPeriod(
-      batch.address,
-      startTime,
-      startTime + 60 * 60 * 24
-    );
-    await goToTime(startTime);
-
-    return batch;
-  }
 });

--- a/packages/contracts/test/contracts/discovery/helpers.ts
+++ b/packages/contracts/test/contracts/discovery/helpers.ts
@@ -1,0 +1,68 @@
+import { ethers } from "hardhat";
+
+import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import {
+  Controller,
+  Batch,
+  Batch__factory,
+  Project,
+  Project__factory,
+  MockERC20,
+} from "../../../src/types";
+
+import { findEvent } from "../../shared/utils";
+import { goToTime, currentTimestamp } from "../../timeHelpers";
+
+const { parseUnits } = ethers.utils;
+
+export async function registerProject(
+  owner: SignerWithAddress,
+  projectToken: MockERC20,
+  controller: Controller
+): Promise<Project> {
+  const tx = await controller.registerProject(
+    "My Project",
+    projectToken.address,
+    parseUnits("1000"),
+    parseUnits("2")
+  );
+
+  const event = await findEvent(tx, "ProjectRegistered");
+  const projectAddress = event?.args?.project;
+
+  return Project__factory.connect(projectAddress, owner);
+}
+
+export async function makeProjectReady(
+  project: Project,
+  projectToken: MockERC20
+) {
+  await projectToken.transfer(project.address, parseUnits("1000"));
+  await project.approveByManager();
+  await project.approveByLegal();
+}
+
+export async function setUpBatch(
+  controller: Controller,
+  projects: Project[],
+  owner: SignerWithAddress
+): Promise<Batch> {
+  await controller.createBatch(
+    projects.map((project) => project.address),
+    projects.length
+  );
+  const batch: Batch = await Batch__factory.connect(
+    await controller.projectsToBatches(projects[0].address),
+    owner
+  );
+  const startTime: number = (await currentTimestamp()) + 100;
+  await controller.setBatchVotingPeriod(
+    batch.address,
+    startTime,
+    startTime + 60 * 60 * 24,
+    0
+  );
+  await goToTime(startTime);
+
+  return batch;
+}


### PR DESCRIPTION
Why:

* The Batch must check if a user is eligible to vote before allowing
  them to do so. Also, there needs to be a period at which the
  investment in a batch ends, which can (and likely will) be different
  from the end of the voting period.

This change addresses the need by:

* Using the connection between the Batch and Controller so that we can
  keep the Controller as the source of truth on how to check for KYC and
  DAO membership. This did mean we had to change the Batch tests a bit,
  but we were able to reuse the helpers we were using in the Controller
  already. It does make it apparent that our contracts are very
  interconnected.
* Adding a new argument to the setVotingPeriod function, so that we can
  set a duration for which the investment in a batch is possible, even
  after the voting period has ended.