### PR TITLE
Adds total vote limit per user for batch

### DIFF
--- a/packages/contracts/contracts/discovery/Batch.sol
+++ b/packages/contracts/contracts/discovery/Batch.sol
@@ -47,7 +47,7 @@ contract Batch is IBatch, ICommon, ProjectVoting {
     }
 
     constructor(address[] memory _projects, uint256 _slotCount)
-        ProjectVoting(_projects, _slotCount)
+        ProjectVoting(_projects)
     {
         uint256 numProjects = _projects.length;
         require(numProjects > 0, "projects must not be empty");
@@ -124,6 +124,23 @@ contract Batch is IBatch, ICommon, ProjectVoting {
         return
             votingPeriod.start >= block.timestamp &&
             investmentEnd <= block.timestamp;
+    }
+
+    function projectVoting_voteLimitPerUser()
+        public
+        view
+        override(ProjectVoting)
+        returns (uint256)
+    {
+        return slotCount;
+    }
+
+    function hasVotedForProject(address _user, address _project)
+        external
+        view
+        returns (bool)
+    {
+        return userHasVotedForProject[_project][_user];
     }
 
     function setVotingPeriod(

--- a/packages/contracts/contracts/discovery/Batch.sol
+++ b/packages/contracts/contracts/discovery/Batch.sol
@@ -47,7 +47,7 @@ contract Batch is IBatch, ICommon, ProjectVoting {
     }
 
     constructor(address[] memory _projects, uint256 _slotCount)
-        ProjectVoting(_projects)
+        ProjectVoting(_projects, _slotCount)
     {
         uint256 numProjects = _projects.length;
         require(numProjects > 0, "projects must not be empty");

--- a/packages/contracts/contracts/discovery/ProjectVoting.sol
+++ b/packages/contracts/contracts/discovery/ProjectVoting.sol
@@ -34,6 +34,9 @@ abstract contract ProjectVoting is ICommon {
     /// user => votes
     mapping(address => uint256) public userVoteCount;
 
+    /// number of votes a user has in total
+    uint256 public voteLimit;
+
     /// project address => votes
     mapping(address => uint256) public projectVoteCount;
 
@@ -49,12 +52,14 @@ abstract contract ProjectVoting is ICommon {
 
     uint256 projectsWithVotesCount;
 
-    constructor(address[] memory _projects) {
+
+    constructor(address[] memory _projects, uint256 _voteLimit) {
         for (uint256 i = 0; i < _projects.length; i++) {
             votes.push(0);
             votesIndexToProject[i] = _projects[i];
             projectToVotesIndex[_projects[i]] = i;
         }
+        voteLimit = _voteLimit;
     }
 
     function projectVoting_projects()
@@ -84,6 +89,7 @@ abstract contract ProjectVoting is ICommon {
             !userHasVotedForProject[projectAddress][msg.sender],
             "already voted in this project"
         );
+        require(userVoteCount[msg.sender] <= voteLimit, "vote limit reached");
         _defineWinners();
         require(
             projectStatuses[projectAddress] == ProjectStatus.InProgress,

--- a/packages/contracts/contracts/discovery/ProjectVoting.sol
+++ b/packages/contracts/contracts/discovery/ProjectVoting.sol
@@ -52,7 +52,6 @@ abstract contract ProjectVoting is ICommon {
 
     uint256 projectsWithVotesCount;
 
-
     constructor(address[] memory _projects, uint256 _voteLimit) {
         for (uint256 i = 0; i < _projects.length; i++) {
             votes.push(0);

--- a/packages/contracts/contracts/discovery/ProjectVoting.sol
+++ b/packages/contracts/contracts/discovery/ProjectVoting.sol
@@ -34,9 +34,6 @@ abstract contract ProjectVoting is ICommon {
     /// user => votes
     mapping(address => uint256) public userVoteCount;
 
-    /// number of votes a user has in total
-    uint256 public voteLimit;
-
     /// project address => votes
     mapping(address => uint256) public projectVoteCount;
 
@@ -52,13 +49,12 @@ abstract contract ProjectVoting is ICommon {
 
     uint256 projectsWithVotesCount;
 
-    constructor(address[] memory _projects, uint256 _voteLimit) {
+    constructor(address[] memory _projects) {
         for (uint256 i = 0; i < _projects.length; i++) {
             votes.push(0);
             votesIndexToProject[i] = _projects[i];
             projectToVotesIndex[_projects[i]] = i;
         }
-        voteLimit = _voteLimit;
     }
 
     function projectVoting_projects()
@@ -83,12 +79,21 @@ abstract contract ProjectVoting is ICommon {
 
     function projectVoting_finalBonus() public view virtual returns (int256);
 
+    function projectVoting_voteLimitPerUser()
+        public
+        view
+        virtual
+        returns (uint256);
+
     function _vote(address projectAddress) internal {
         require(
             !userHasVotedForProject[projectAddress][msg.sender],
             "already voted in this project"
         );
-        require(userVoteCount[msg.sender] < voteLimit, "vote limit reached");
+        require(
+            userVoteCount[msg.sender] < projectVoting_voteLimitPerUser(),
+            "vote limit reached"
+        );
         _defineWinners();
         require(
             projectStatuses[projectAddress] == ProjectStatus.InProgress,

--- a/packages/contracts/contracts/discovery/ProjectVoting.sol
+++ b/packages/contracts/contracts/discovery/ProjectVoting.sol
@@ -88,7 +88,7 @@ abstract contract ProjectVoting is ICommon {
             !userHasVotedForProject[projectAddress][msg.sender],
             "already voted in this project"
         );
-        require(userVoteCount[msg.sender] <= voteLimit, "vote limit reached");
+        require(userVoteCount[msg.sender] < voteLimit, "vote limit reached");
         _defineWinners();
         require(
             projectStatuses[projectAddress] == ProjectStatus.InProgress,

--- a/packages/contracts/contracts/discovery/TestProjectVoting.sol
+++ b/packages/contracts/contracts/discovery/TestProjectVoting.sol
@@ -14,7 +14,7 @@ contract TestProjectVoting is ProjectVoting {
         Period memory _votingPeriod,
         address[] memory _projects,
         uint256 _numSlots
-    ) ProjectVoting(_projects) {
+    ) ProjectVoting(_projects, _numSlots) {
         votingPeriod = _votingPeriod;
         projects = _projects;
         numSlots = _numSlots;

--- a/packages/contracts/contracts/discovery/TestProjectVoting.sol
+++ b/packages/contracts/contracts/discovery/TestProjectVoting.sol
@@ -14,7 +14,7 @@ contract TestProjectVoting is ProjectVoting {
         Period memory _votingPeriod,
         address[] memory _projects,
         uint256 _numSlots
-    ) ProjectVoting(_projects, _numSlots) {
+    ) ProjectVoting(_projects) {
         votingPeriod = _votingPeriod;
         projects = _projects;
         numSlots = _numSlots;
@@ -63,6 +63,15 @@ contract TestProjectVoting is ProjectVoting {
         returns (int256)
     {
         return 0;
+    }
+
+    function projectVoting_voteLimitPerUser()
+        public
+        view
+        override(ProjectVoting)
+        returns (uint256)
+    {
+        return numSlots;
     }
 
     function test_vote(address projectAddress) external {

--- a/packages/contracts/test/contracts/discovery/Batch.ts
+++ b/packages/contracts/test/contracts/discovery/Batch.ts
@@ -197,6 +197,21 @@ describe("Batch", () => {
       ).to.be.revertedWith("already voted in this project");
     });
 
+    it("does not give users more votes than slots", async () => {
+      batch = await new Batch__factory(owner).deploy(
+        [fakeProject.address, anotherFakeProject.address],
+        1
+      );
+      await batch.setVotingPeriod(votingStart, votingEnd);
+      await goToTime(votingStart);
+
+      await batch.connect(alice).vote(fakeProject.address);
+
+      await expect(
+        batch.connect(alice).vote(anotherFakeProject.address)
+      ).to.be.revertedWith("vote limit reached");
+    });
+
     it("does not allow a user to vote before the voting period is set", async () => {
       const newProject: Project = await registerProject(
         owner,

--- a/packages/contracts/test/contracts/discovery/Batch.ts
+++ b/packages/contracts/test/contracts/discovery/Batch.ts
@@ -202,8 +202,8 @@ describe("Batch", () => {
         [fakeProject.address, anotherFakeProject.address],
         1
       );
-      await batch.setVotingPeriod(votingStart, votingEnd);
-      await goToTime(votingStart);
+      await batch.setVotingPeriod(votingStart + oneDay, votingEnd);
+      await goToTime(votingStart + oneDay);
 
       await batch.connect(alice).vote(fakeProject.address);
 

--- a/packages/contracts/test/contracts/discovery/Batch.ts
+++ b/packages/contracts/test/contracts/discovery/Batch.ts
@@ -198,11 +198,32 @@ describe("Batch", () => {
     });
 
     it("does not give users more votes than slots", async () => {
-      batch = await new Batch__factory(owner).deploy(
-        [fakeProject.address, anotherFakeProject.address],
+      fakeProject = await registerProject(
+        owner,
+        projectToken,
+        controller,
+        aUSD
+      );
+      await makeProjectReady(fakeProject, projectToken);
+      anotherFakeProject = await registerProject(
+        owner,
+        projectToken,
+        controller,
+        aUSD
+      );
+      await makeProjectReady(anotherFakeProject, projectToken);
+      batch = await setUpBatch(
+        controller,
+        [fakeProject, anotherFakeProject],
+        owner,
         1
       );
-      await batch.setVotingPeriod(votingStart + oneDay, votingEnd);
+      await controller.setBatchVotingPeriod(
+        batch.address,
+        votingStart + oneDay,
+        votingEnd,
+        0
+      );
       await goToTime(votingStart + oneDay);
 
       await batch.connect(alice).vote(fakeProject.address);

--- a/packages/contracts/test/contracts/discovery/ProjectVoting.ts
+++ b/packages/contracts/test/contracts/discovery/ProjectVoting.ts
@@ -224,7 +224,7 @@ describe("ProjectVoting", () => {
         await goToTime(votingStart + oneDay);
         await projectVoting.connect(alice).test_vote(project1.address);
         await goToTime(votingStart + 2 * oneDay);
-        await projectVoting.connect(alice).test_vote(project3.address);
+        await projectVoting.connect(bob).test_vote(project3.address);
 
         await goToTime(votingStart + 5 * oneDay);
         const winners = await projectVoting.test_getWinners();

--- a/packages/contracts/test/contracts/discovery/helpers.ts
+++ b/packages/contracts/test/contracts/discovery/helpers.ts
@@ -47,11 +47,12 @@ export async function makeProjectReady(
 export async function setUpBatch(
   controller: Controller,
   projects: Project[],
-  owner: SignerWithAddress
+  owner: SignerWithAddress,
+  slotCount?: number
 ): Promise<Batch> {
   await controller.createBatch(
     projects.map((project) => project.address),
-    projects.length
+    slotCount || projects.length
   );
   const batch: Batch = await Batch__factory.connect(
     await controller.projectsToBatches(projects[0].address),


### PR DESCRIPTION
Why:

* We want to decentivize users from voting in every project just to get
  into the people's pool.

This change addresses the need by:

* Adding a limit to the amount of votes a user has in a batch, which is
  equal to the number of slots.