### PR TITLE
Tidy label size with Reviewpad

### DIFF
--- a/revy.yml
+++ b/revy.yml
@@ -48,10 +48,16 @@ protectionGates:
     patchRules:
       - rule: isSmall
         extraActions:
+          - $removeLabel("medium")
+          - $removeLabel("large")
           - $addLabel("small")
       - rule: isMedium
         extraActions:
+          - $removeLabel("small")
+          - $removeLabel("large")
           - $addLabel("medium")
       - rule: isLarge
         extraActions:
+          - $removeLabel("small")
+          - $removeLabel("medium")
           - $addLabel("large")


### PR DESCRIPTION
This pull request improves the action size labelling by ensuring that only one of the "small", "medium" and "large" labels are applied to a single pull request.