### PR TITLE
Add wrong network selected modal

### DIFF
--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -64,6 +64,10 @@ Its used to open Contribute Again info URL.
 
 Its used to open Fractal KYC profile URL.
 
+## NEXT_PUBLIC_CHAIN_ID
+
+Its used to force metamask connect to this chain ID.
+
 ## NEXT_PUBLIC_DAO_CONTRACTS_FOLDER
 
 This application will run with the `mandala (staging)` contracts by default.

--- a/packages/web/src/components/modals/wrong-chain-modal.tsx
+++ b/packages/web/src/components/modals/wrong-chain-modal.tsx
@@ -1,0 +1,89 @@
+/**
+ * Module dependencies.
+ */
+
+import { Button } from 'src/components/core/button';
+import { Container } from 'src/components/core/container';
+import { Modal } from 'src/components/core/modal';
+import { Text } from 'src/components/core/text';
+import { media } from 'src/styles/breakpoints';
+import React from 'react';
+import styled from 'styled-components';
+
+/**
+ * `Props` type.
+ */
+
+type Props = {
+  chainName: string;
+  isOpen: boolean;
+  onChangeNetwork: any;
+};
+
+/**
+ * `Title` styled component.
+ */
+
+const Title = styled(Text).attrs({
+  as: 'p',
+  variant: 'lead'
+})`
+  margin-bottom: 3rem;
+`;
+
+/**
+ * `Lead` styled component.
+ */
+
+const Lead = styled(Text)`
+  margin: 0;
+
+  ${media.min.sm`
+    padding: 0 3rem;
+  `}
+`;
+
+/**
+ * `Content` styled component.
+ */
+
+const Content = styled(Container)`
+  ${media.max.sm`
+    padding: 0.5rem;
+  `}
+`;
+
+/**
+ * `FlexCenter` styled component.
+ */
+
+const FlexCenter = styled.div`
+  align-items: center;
+  display: flex;
+  justify-content: center;
+  padding: 5rem 0;
+`;
+
+/**
+ * Export `WrongChainModal` component.
+ */
+
+export function WrongChainModal(props: Props) {
+  const { chainName, isOpen, onChangeNetwork } = props;
+
+  return (
+    <Modal isOpen={isOpen}>
+      <Title>{'Wrong network selected'}</Title>
+
+      <Content>
+        <Lead>
+          {`The currently selected network cannot interact with our services. Please switch to ${chainName} to continue.`}
+        </Lead>
+
+        <FlexCenter>
+          <Button onClick={onChangeNetwork}>{`Switch to ${chainName}`}</Button>
+        </FlexCenter>
+      </Content>
+    </Modal>
+  );
+}

--- a/packages/web/src/core/utils/web3-connectors.ts
+++ b/packages/web/src/core/utils/web3-connectors.ts
@@ -4,14 +4,71 @@
 
 import { InjectedConnector } from '@web3-react/injected-connector';
 import { WalletConnectConnector } from '@web3-react/walletconnect-connector';
+import { utils } from 'ethers';
+
+/**
+ * `supportedChain` environment variable.
+ */
+
+const supportedChain = process.env.NEXT_PUBLIC_CHAIN_ID || ('31337' as string);
+
+/**
+ * Export `supportedChainIds`.
+ */
+
+export const supportedChainIds = [Number(supportedChain)];
+
+/**
+ * `chainConfigs`.
+ */
+
+export const chainConfigs = {
+  '595': {
+    blockExplorerUrls: ['https://blockscout.mandala.acala.network/'],
+    chainId: utils.hexValue(595),
+    chainName: 'Mandala TC7',
+    nativeCurrency: {
+      decimals: 18,
+      name: 'Acala USD',
+      symbol: 'ACA'
+    },
+    rpcUrls: ['https://tc7-eth.aca-dev.network']
+  },
+  '686': {
+    blockExplorerUrls: ['https://blockscout.karura.network/'],
+    chainId: utils.hexValue(686),
+    chainName: 'Karura',
+    nativeCurrency: {
+      decimals: 18,
+      name: 'Karura USD',
+      symbol: 'KAR'
+    },
+    rpcUrls: ['https://eth-rpc-karura.aca-api.network/']
+  },
+  '31337': {
+    blockExplorerUrls: ['http://127.0.0.1:8545'],
+    chainId: utils.hexValue(595),
+    chainName: 'Localhost',
+    nativeCurrency: {
+      decimals: 18,
+      name: 'Acala USD',
+      symbol: 'ACA'
+    },
+    rpcUrls: ['/']
+  }
+};
+
+/**
+ * `chainConfig`.
+ */
+
+export const chainConfig = chainConfigs?.[supportedChain];
 
 /**
  * `metamask` connector.
  */
 
-const metamask = new InjectedConnector({
-  supportedChainIds: [595, 31337]
-});
+const metamask = new InjectedConnector({ supportedChainIds });
 
 /**
  * `walletconnect` connector.
@@ -19,7 +76,8 @@ const metamask = new InjectedConnector({
 
 const walletconnect = new WalletConnectConnector({
   bridge: 'https://bridge.walletconnect.org',
-  qrcode: true
+  qrcode: true,
+  supportedChainIds
 });
 
 /**

--- a/packages/web/src/hooks/use-referral-url.ts
+++ b/packages/web/src/hooks/use-referral-url.ts
@@ -11,7 +11,7 @@ import { useWeb3React } from '@web3-react/core';
  * Export `useReferralUrl` hook.
  */
 
-export function useReferralUrl() {
+export function useReferralUrl(): string | undefined {
   const { account } = useWeb3React<Web3Provider>();
 
   if (!account) {


### PR DESCRIPTION
This prevents the user from trying to use a wrong network through Metamask.
Closes https://github.com/subvisual/discoveryDAO/issues/113

**Now, once the user interacts with _Metamask_:**
- It will try to switch to the correct (Mandala/Karura) network
- If the network is not configured, it will try to add it's configuration it to Metamask and select it.
- If any of those procedure fails, it will throw an error.

**Vercel should be update with the following env variables:** 
Staging: `NEXT_PUBLIC_CHAIN_ID=595` 
Production: `NEXT_PUBLIC_CHAIN_ID=686`

## Screenshot
<img src="https://user-images.githubusercontent.com/3527721/166224678-62306dfe-7271-4d6e-9ffc-958c51637922.png" width="400" />

