### PR TITLE
Fix Tokens release date for first of next month

### DIFF
--- a/packages/web/src/components/vesting/index.tsx
+++ b/packages/web/src/components/vesting/index.tsx
@@ -6,10 +6,11 @@ import { ClaimActionCard } from './styles';
 import { InfoCard } from './info-card';
 import { LoadingModal } from 'src/components/modals/loading-modal';
 import { currencyConfig } from 'src/core/constants';
-import { formatCurrency } from 'src/core/utils/formatters';
+import { formatCurrency, formatDate } from 'src/core/utils/formatters';
 import { media } from 'src/styles/breakpoints';
 import { useClaim, useRefund, useVesting } from 'src/hooks/use-vesting';
 import React, { useMemo } from 'react';
+import formatISO from 'date-fns/formatISO';
 import styled from 'styled-components';
 
 /**
@@ -25,6 +26,16 @@ const Grid = styled.section`
     grid-template-columns: 2fr 1fr 1fr;
   `}
 `;
+
+/**
+ * `getFirstDayOfNextMonth`.
+ */
+
+function getFirstDayOfNextMonth() {
+  const date = new Date();
+
+  return new Date(date.getFullYear(), date.getMonth() + 1, 1);
+}
 
 /**
  * Export `Vesting` component.
@@ -50,7 +61,9 @@ export function Vesting() {
   return (
     <Grid>
       <InfoCard
-        nextRelease={vestingState.nextRelease}
+        nextRelease={formatDate(formatISO(getFirstDayOfNextMonth()), {
+          hideHours: true
+        })}
         tokens={tokens}
         totalClaimed={totalClaimed}
       />

--- a/packages/web/src/components/vesting/info-card.tsx
+++ b/packages/web/src/components/vesting/info-card.tsx
@@ -65,7 +65,7 @@ export function InfoCard(props: Props) {
         </FlexRow>
 
         <FlexRow>
-          <Text variant={'label'}>{'Next Realease'}</Text>
+          <Text variant={'label'}>{'Next Release'}</Text>
           <Text noMargin>{nextRelease}</Text>
         </FlexRow>
       </Grid>

--- a/packages/web/src/core/utils/formatters.ts
+++ b/packages/web/src/core/utils/formatters.ts
@@ -215,10 +215,15 @@ export function formatCompactNumber(
  * Export `formatDate`.
  */
 
-export function formatDate(date: string) {
+export function formatDate(date: string, options?: { hideHours: boolean }) {
+  const { hideHours } = options ?? {};
+
   if (!date) {
     return '';
   }
 
-  return format(parseISO(date), 'dd/MM/yyyy HH:mm OOOO');
+  return format(
+    parseISO(date),
+    hideHours ? 'dd/MM/yyyy' : 'dd/MM/yyyy HH:mm OOOO'
+  );
 }


### PR DESCRIPTION
This adds the Release date to be the first of the next month as discussed with @zamith.
This fixes the previously TODO and should still be enhanced later as of right now we don't have more info on it.

## Screenshots
| After | Before |
| --- | --- |
|<img src="https://user-images.githubusercontent.com/3527721/166229343-4fd7b436-1388-4aee-a81a-ca364fc17125.png" width="400" /> | <img src="https://user-images.githubusercontent.com/3527721/166229387-e7901746-f347-4497-8ff2-06e424d10ff1.png" width="400" /> |