### PR TITLE
Fix network select modal not appearing

### DIFF
--- a/packages/web/src/core/utils/web3-connectors.ts
+++ b/packages/web/src/core/utils/web3-connectors.ts
@@ -10,7 +10,7 @@ import { utils } from 'ethers';
  * `supportedChain` environment variable.
  */
 
-const supportedChain = process.env.NEXT_PUBLIC_CHAIN_ID || ('31337' as string);
+const supportedChain: string = process.env.NEXT_PUBLIC_CHAIN_ID || '31337';
 
 /**
  * Export `supportedChainIds`.

--- a/packages/web/src/pages/_app.tsx
+++ b/packages/web/src/pages/_app.tsx
@@ -102,7 +102,7 @@ const PageApp = (props: AppProps) => {
       <div id={'modalPortal'} />
 
       <ToastContainer
-        autoClose={10000}
+        autoClose={4000}
         closeOnClick
         hideProgressBar
         limit={3}


### PR DESCRIPTION
This PR fixes the Network modal not appearing because the error from Metamask is different in staging for unknown reasons.
To tackle this, we check the for the error message too.

