### PR TITLE
Fixing decimal places

### DIFF
--- a/packages/web/src/hooks/use-sale.ts
+++ b/packages/web/src/hooks/use-sale.ts
@@ -56,18 +56,23 @@ export function useSale() {
     }
 
     try {
-      const balance = await contracts.sale1.uncappedAllocation(account);
-      const myContribution = await contracts.sale1.paymentTokenToToken(balance);
+      const contributionCtnd = await contracts.sale1.uncappedAllocation(
+        account
+      );
+      const contributionAusd = await contracts.sale1.tokenToPaymentToken(
+        contributionCtnd
+      );
       const investorCount = await contracts.sale1.investorCount();
       const raisedTokens = await contracts.sale1.allocated();
       const raised = await contracts.sale1.tokenToPaymentToken(raisedTokens);
       const price = await contracts.sale1.rate();
+      const aUsdDecimals = await contracts.aUsd.decimals();
 
       setState({
-        balance: utils.formatUnits(myContribution.toString()),
+        balance: utils.formatUnits(contributionAusd, aUsdDecimals),
         contributions: investorCount.toString(),
-        price: utils.formatUnits(price.toString()),
-        raised: utils.formatUnits(raised.toString())
+        price: utils.formatUnits(price, aUsdDecimals),
+        raised: utils.formatUnits(raised, aUsdDecimals)
       });
     } catch (error) {
       // Handle error


### PR DESCRIPTION
There were a couple of problems I noticed in `use-sale.tsx`:

1. Use of `formatUnits` was incorrect. It can't receive a string, but rather a bignumber (so `parseUnits(price.toString())` should actually be `parseUnits(price)`. It also should receive a second argument with the number of decimal places to consider, unless the default 18 is to be used. Since aUsd has 12, we need to query the contract for that info
2. The "My contribution" column is suposed to show the total aUsd contribution made. But the `uncappedAllocation` call returns a CTND amount, so this needs to be converted to aUsd before displayed