### PR TITLE
Vesting updates based on feedback

### DIFF
--- a/packages/contracts/contracts/token/IVesting.sol
+++ b/packages/contracts/contracts/token/IVesting.sol
@@ -50,8 +50,7 @@ interface IVesting {
 
     /**
      * Creates a new vesting with private sale parameters
-     * If the address is already registered, it does nothing. If the address
-     * has been registered in a public sale, it reverts the transaction
+     * If the address is already registered, it does nothing.
      *
      * Also checks if the private sale cap has been reached, and if so,
      * reverts.
@@ -59,12 +58,14 @@ interface IVesting {
      * @param to Beneficiary
      * @param amount Amount of tokens to vest
      * @param cliffMonths Number of months to wait before the vesting starts
+     * @param vestingMonths Number of months of vesting
      * @param nonce Nonce used to prevent the same sale from being registered twice
      **/
     function createPrivateSaleVest(
         address to,
         uint256 amount,
         uint16 cliffMonths,
+        uint16 vestingMonths,
         uint64 nonce
     ) external;
 

--- a/packages/contracts/contracts/token/Vesting.sol
+++ b/packages/contracts/contracts/token/Vesting.sol
@@ -47,8 +47,7 @@ contract Vesting is IVesting, AccessControl, ReentrancyGuard {
     address[] public sales;
 
     uint256 public constant PRIVATE_SALE_MAX_CLIFF_MONTHS = 6;
-    bytes32 public constant PRIVATE_SELLER_ROLE =
-        keccak256("PRIVATE_SELLER_ROLE");
+    bytes32 public constant SALE_MANAGER_ROLE = keccak256("SALE_MANAGER_ROLE");
 
     event ClaimVesting(address indexed to, uint256 amount);
     event AddSale(address indexed saleContract);
@@ -64,7 +63,7 @@ contract Vesting is IVesting, AccessControl, ReentrancyGuard {
         uint256 _privateSaleCap
     ) {
         _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
-        _grantRole(PRIVATE_SELLER_ROLE, msg.sender);
+        _grantRole(SALE_MANAGER_ROLE, msg.sender);
 
         publicSaleVestingMonths = _publicSaleVestingMonths;
         publicSaleCliffMonths = 0;
@@ -162,7 +161,7 @@ contract Vesting is IVesting, AccessControl, ReentrancyGuard {
     )
         external
         override(IVesting)
-        onlyRole(PRIVATE_SELLER_ROLE)
+        onlyRole(SALE_MANAGER_ROLE)
         nonReentrant
         useNonce(nonce)
     {
@@ -194,7 +193,7 @@ contract Vesting is IVesting, AccessControl, ReentrancyGuard {
 
     function setStartTime(uint256 _startTime)
         public
-        onlyRole(DEFAULT_ADMIN_ROLE)
+        onlyRole(SALE_MANAGER_ROLE)
     {
         require(startTime == 0, "start time already set");
         startTime = _startTime;

--- a/packages/contracts/contracts/token/Vesting.sol
+++ b/packages/contracts/contracts/token/Vesting.sol
@@ -183,6 +183,7 @@ contract Vesting is IVesting, AccessControl, ReentrancyGuard {
             vesting.amount == 0 || vesting.vestingMonths == vestingMonths,
             "vesting already exists with different vesting period"
         );
+        require(vestingMonths >= publicSaleVestingMonths, "vesting too short");
 
         vesting.cliffMonths = cliffMonths;
         vesting.vestingMonths = vestingMonths;

--- a/packages/contracts/contracts/token/Vesting.sol
+++ b/packages/contracts/contracts/token/Vesting.sol
@@ -195,6 +195,7 @@ contract Vesting is IVesting, AccessControl, ReentrancyGuard {
         public
         onlyRole(DEFAULT_ADMIN_ROLE)
     {
+        require(startTime == 0, "start time already set");
         startTime = _startTime;
     }
 

--- a/packages/contracts/deploy/ctnd/vesting.deploy.ts
+++ b/packages/contracts/deploy/ctnd/vesting.deploy.ts
@@ -14,7 +14,7 @@ const func: DeployFunction = async function (hre) {
   await acalaDeploy(hre, "Vesting", {
     log: true,
     from: deployer,
-    args: [3, citizend.address, [], ctndVesting.start, 10000], // TODO input correct private sale value
+    args: [3, citizend.address, [], 10000], // TODO input correct private sale value
   });
 };
 

--- a/packages/contracts/src/tasks/ctnd/privateSale.ts
+++ b/packages/contracts/src/tasks/ctnd/privateSale.ts
@@ -13,6 +13,7 @@ interface Row {
   address: string;
   amount: string;
   cliff: number;
+  vestingMonths: number;
   nonce: number;
 }
 
@@ -27,13 +28,19 @@ async function importCSV(hre: HardhatRuntimeEnvironment, file: string) {
   const rows = await readCSV(file);
 
   for (let current = 0; current < rows.length; current += 1) {
-    const { address, amount, cliff, nonce } = rows[current];
+    const { address, amount, cliff, vestingMonths, nonce } = rows[current];
 
     const amountInCents = parseUnits(amount);
 
     // TODO check nonce
     if (true) {
-      await vesting.createPrivateSaleVest(address, amountInCents, cliff, nonce);
+      await vesting.createPrivateSaleVest(
+        address,
+        amountInCents,
+        cliff,
+        vestingMonths,
+        nonce
+      );
     }
   }
 }
@@ -50,6 +57,7 @@ function readCSV(file: string): Promise<Row[]> {
           address: row.Address,
           amount: row.Amount,
           cliff: row.Cliff,
+          vestingMonths: row.Vesting,
           nonce: row.Nonce,
         })
       )

--- a/packages/contracts/test/contracts/token/Vesting.ts
+++ b/packages/contracts/test/contracts/token/Vesting.ts
@@ -88,6 +88,14 @@ describe("Vesting", () => {
 
   describe("setStartTime", () => {
     it("sets the start time", async () => {
+      vesting = await new Vesting__factory(owner).deploy(
+        3,
+        citizend.address,
+        [sale.address],
+        10000,
+        await acalaDeployParams()
+      );
+
       await vesting.setStartTime(vestingStart);
       expect(await vesting.startTime()).to.eq(vestingStart);
     });
@@ -236,13 +244,19 @@ describe("Vesting", () => {
     });
 
     it("does not create vestings for the same address with a different vesting period", async () => {
-      await vesting.createPrivateSaleVest(alice.address, 300, 0, 0, 123);
+      await vesting.createPrivateSaleVest(alice.address, 300, 0, 3, 123);
 
       await expect(
-        vesting.createPrivateSaleVest(alice.address, 300, 0, 1, 124)
+        vesting.createPrivateSaleVest(alice.address, 300, 0, 4, 124)
       ).to.be.revertedWith(
         "vesting already exists with different vesting period"
       );
+    });
+
+    it("does not create vestings with less vesting months than the public sale", async () => {
+      await expect(
+        vesting.createPrivateSaleVest(alice.address, 300, 0, 1, 124)
+      ).to.be.revertedWith("vesting too short");
     });
   });
 

--- a/packages/contracts/test/integration/ctnd.sale.ts
+++ b/packages/contracts/test/integration/ctnd.sale.ts
@@ -8,6 +8,7 @@ import {
   decreaseTime,
   currentDate,
 } from "../timeHelpers";
+import { getNetworkConfig } from "../../src/deployConfigs";
 
 import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import {
@@ -39,6 +40,7 @@ describe("Integration", () => {
 
   const fixture = deployments.createFixture(async ({ deployments, ethers }) => {
     await deployments.fixture(["ctnd"]);
+    const { ctndVesting } = await getNetworkConfig();
 
     [owner, alice, seller] = await ethers.getSigners();
 
@@ -66,6 +68,8 @@ describe("Integration", () => {
     await aUSD.connect(alice).approve(sale.address, allowance);
     await aUSD.connect(alice).approve(secondSale.address, allowance);
     await registry.addUserAddress(alice.address, formatBytes32String("id1"));
+
+    await vesting.setStartTime(ctndVesting.start);
   });
 
   beforeEach(async () => {


### PR DESCRIPTION
Why:

* In order to fulfill the requirements from the product team, we need to
  be able to set the start time for the vesting after the deployment of
  the contract and set the vesting months for the private investors

This change addresses the need by:

* Adding the vesting months to the parameters of the create private sale
  function, which also checks that we are not changing the vesting
  period of an existing account.
* Allowing the start time to be set at any time, returns 0 periods
  elapsed while the start time is not set