### PR TITLE
Require full KYC to invest

### DIFF
--- a/packages/contracts/contracts/token/Sale.sol
+++ b/packages/contracts/contracts/token/Sale.sol
@@ -194,6 +194,10 @@ contract Sale is ISale, RisingTide, ERC165, AccessControl, ReentrancyGuard {
                 fractalIdToAddress[fractalId] == msg.sender,
             "id registered to another address"
         );
+        require(
+            FractalRegistry(registry).isUserInList(fractalId, "plus"),
+            "not full kyc"
+        );
 
         uint256 paymentAmount = tokenToPaymentToken(_amount);
         require(paymentAmount > 0, "can't be zero");

--- a/packages/contracts/scripts/test.kycWhitelist.ts
+++ b/packages/contracts/scripts/test.kycWhitelist.ts
@@ -26,7 +26,7 @@ async function main() {
 
   for (const { address, id } of whitelist) {
     await registry.addUserAddress(address, id);
-    await registry.addUserToList(id, "kycPlus");
+    await registry.addUserToList(id, "plus");
   }
 }
 

--- a/packages/contracts/test/contracts/token/Sale.ts
+++ b/packages/contracts/test/contracts/token/Sale.ts
@@ -59,7 +59,9 @@ describe("Sale", () => {
     await aUSD.connect(bob).approve(sale.address, MaxUint256);
 
     await registry.addUserAddress(alice.address, formatBytes32String("id1"));
+    await registry.addUserToList(formatBytes32String("id1"), "plus");
     await registry.addUserAddress(bob.address, formatBytes32String("id2"));
+    await registry.addUserToList(formatBytes32String("id2"), "plus");
   });
 
   describe("constructor", () => {

--- a/packages/contracts/test/integration/ctnd.sale.ts
+++ b/packages/contracts/test/integration/ctnd.sale.ts
@@ -68,7 +68,7 @@ describe("Integration", () => {
     await aUSD.connect(alice).approve(sale.address, allowance);
     await aUSD.connect(alice).approve(secondSale.address, allowance);
     await registry.addUserAddress(alice.address, formatBytes32String("id1"));
-
+    await registry.addUserToList(formatBytes32String("id1"), "plus");
     await vesting.setStartTime(ctndVesting.start);
   });
 

--- a/packages/contracts/test/tasks/ctnd/risingTide.ts
+++ b/packages/contracts/test/tasks/ctnd/risingTide.ts
@@ -93,11 +93,9 @@ describe("ctnd:risingTide task", () => {
         .connect(signer)
         .mint(signer.address, parseUnits("1000", decimals));
       await aUSD.connect(signer).approve(sale.address, MaxUint256);
-      await registry.addUserAddress(
-        signer.address,
-        ethers.utils.randomBytes(32)
-      );
-
+      const fractalId = ethers.utils.randomBytes(32);
+      await registry.addUserAddress(signer.address, fractalId);
+      await registry.addUserToList(fractalId, "plus");
       await sale.connect(signer).buy(amount);
     }
   }

--- a/packages/web/src/hooks/use-owner-action.ts
+++ b/packages/web/src/hooks/use-owner-action.ts
@@ -24,7 +24,7 @@ function bytes32(value: string): string {
  */
 
 export const ListId = bytes32('42');
-export const ListName = process.env.NEXT_PUBLIC_KYC_LIST_NAME ?? 'kycPlus';
+export const ListName = process.env.NEXT_PUBLIC_KYC_LIST_NAME ?? 'plus';
 
 /**
  * `useOwnerAction`.


### PR DESCRIPTION
Why:

* As part of the sale we want to ensure investors have gone through the
  full KYC

This change addresses the need by:

* Checking their fractal ID is on the plus list