### PR TITLE
Fix timezones mismatch and blockchain data loading

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -36,7 +36,7 @@
     "@web3-react/injected-connector": "^6.0.7",
     "@web3-react/walletconnect-connector": "^6.2.13",
     "bignumber.js": "^9.0.2",
-    "date-fns": "^2.28.0",
+    "dayjs": "^1.11.1",
     "lodash": "^4.17.21",
     "next": "^12.0.4",
     "react": "^17.0.2",

--- a/packages/web/src/components/dashboard/project-info-card.tsx
+++ b/packages/web/src/components/dashboard/project-info-card.tsx
@@ -3,6 +3,7 @@
  */
 
 import { Card } from 'src/components/core/card';
+import { Loader } from 'src/components/core/loading';
 import { Separator } from 'src/components/core/separator';
 import { Text } from 'src/components/core/text';
 import { media } from 'src/styles/breakpoints';
@@ -14,8 +15,9 @@ import styled from 'styled-components';
  */
 
 type Props = {
-  myContribution: string;
   contributions: string;
+  isLoading: boolean;
+  myContribution: string;
   price: string;
   raised: string;
   vestingStart: string;
@@ -34,6 +36,20 @@ const StyledCard = styled(Card)`
   ${media.min.md`
     flex-direction: row;
   `}
+`;
+
+/**
+ * `LoadingCard` styled component.
+ */
+
+const LoadingCard = styled(Card)`
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  grid-gap: 2rem;
+  justify-content: center;
+  padding-top: 5rem;
+  position: relative;
 `;
 
 /**
@@ -80,7 +96,28 @@ const Value = styled(Text).attrs({ as: 'p' })`
  */
 
 export function ProjectInfoCard(props: Props) {
-  const { contributions, myContribution, price, raised, vestingStart } = props;
+  const {
+    contributions,
+    isLoading,
+    myContribution,
+    price,
+    raised,
+    vestingStart
+  } = props;
+
+  if (isLoading) {
+    return (
+      <LoadingCard>
+        <Text as={'p'} variant={'body2'}>
+          {'Loading'}
+        </Text>
+        <Loader size={1} />
+        <Text as={'p'} variant={'body'}>
+          {'We are fetching blockchain data...'}
+        </Text>
+      </LoadingCard>
+    );
+  }
 
   return (
     <StyledCard>

--- a/packages/web/src/components/vesting/index.tsx
+++ b/packages/web/src/components/vesting/index.tsx
@@ -6,11 +6,11 @@ import { ClaimActionCard } from './styles';
 import { InfoCard } from './info-card';
 import { LoadingModal } from 'src/components/modals/loading-modal';
 import { currencyConfig } from 'src/core/constants';
-import { formatCurrency, formatDate } from 'src/core/utils/formatters';
+import { formatCurrency } from 'src/core/utils/formatters';
 import { media } from 'src/styles/breakpoints';
 import { useClaim, useRefund, useVesting } from 'src/hooks/use-vesting';
 import React, { useMemo } from 'react';
-import formatISO from 'date-fns/formatISO';
+import dayjs from 'src/core/utils/dayjs';
 import styled from 'styled-components';
 
 /**
@@ -33,9 +33,12 @@ const Grid = styled.section`
  */
 
 function getFirstDayOfNextMonth() {
-  const date = new Date();
+  const now = dayjs();
 
-  return new Date(date.getFullYear(), date.getMonth() + 1, 1);
+  return now
+    .month(now.month() + 1)
+    .date(1)
+    .format('DD/MM/YYYY');
 }
 
 /**
@@ -62,9 +65,7 @@ export function Vesting() {
   return (
     <Grid>
       <InfoCard
-        nextRelease={formatDate(formatISO(getFirstDayOfNextMonth()), {
-          hideHours: true
-        })}
+        nextRelease={getFirstDayOfNextMonth()}
         tokens={tokens}
         totalClaimed={totalClaimed}
       />

--- a/packages/web/src/core/utils/dayjs.ts
+++ b/packages/web/src/core/utils/dayjs.ts
@@ -1,0 +1,21 @@
+/**
+ * Module dependencies.
+ */
+
+import dayjs from 'dayjs';
+import timezone from 'dayjs/plugin/timezone';
+import utc from 'dayjs/plugin/utc';
+
+/**
+ * Register `dayjs` plugins.
+ */
+
+dayjs.extend(timezone);
+dayjs.extend(utc);
+dayjs.tz.setDefault('Europe/Lisbon');
+
+/**
+ * Export dayjs with timezone.
+ */
+
+export default dayjs;

--- a/packages/web/src/core/utils/formatters.ts
+++ b/packages/web/src/core/utils/formatters.ts
@@ -6,9 +6,8 @@
 
 import { NumericValue, roundDown, roundUp } from './math';
 import BigNumber from 'bignumber.js';
+import dayjs from 'src/core/utils/dayjs';
 import dropWhile from 'lodash/dropWhile';
-import format from 'date-fns/format';
-import parseISO from 'date-fns/parseISO';
 import size from 'lodash/size';
 import takeWhile from 'lodash/takeWhile';
 
@@ -228,18 +227,13 @@ export function formatCompactNumber(
 }
 
 /**
- * Export `formatDate`.
+ * Export `formatFromUnix`.
  */
 
-export function formatDate(date: string, options?: { hideHours: boolean }) {
-  const { hideHours } = options ?? {};
-
+export function formatFromUnix(date: number) {
   if (!date) {
     return '';
   }
 
-  return format(
-    parseISO(date),
-    hideHours ? 'dd/MM/yyyy' : 'dd/MM/yyyy HH:mm OOOO'
-  );
+  return dayjs.unix(date).utc().format('DD/MM/YYYY hh:mm Z');
 }

--- a/packages/web/src/core/utils/web3-connectors.ts
+++ b/packages/web/src/core/utils/web3-connectors.ts
@@ -10,7 +10,7 @@ import { utils } from 'ethers';
  * `supportedChain` environment variable.
  */
 
-const supportedChain: string = process.env.NEXT_PUBLIC_CHAIN_ID || '31337';
+const supportedChain: string = process.env.NEXT_PUBLIC_CHAIN_ID || '595';
 
 /**
  * Export `supportedChainIds`.
@@ -28,8 +28,8 @@ export const chainConfigs = {
     chainId: utils.hexValue(595),
     chainName: 'Mandala TC7',
     nativeCurrency: {
-      decimals: 18,
-      name: 'Acala USD',
+      decimals: 12,
+      name: 'Acala',
       symbol: 'ACA'
     },
     rpcUrls: ['https://tc7-eth.aca-dev.network']
@@ -39,19 +39,19 @@ export const chainConfigs = {
     chainId: utils.hexValue(686),
     chainName: 'Karura',
     nativeCurrency: {
-      decimals: 18,
-      name: 'Karura USD',
+      decimals: 12,
+      name: 'Karura',
       symbol: 'KAR'
     },
     rpcUrls: ['https://eth-rpc-karura.aca-api.network/']
   },
   '31337': {
     blockExplorerUrls: ['http://127.0.0.1:8545'],
-    chainId: utils.hexValue(595),
+    chainId: utils.hexValue(31337),
     chainName: 'Localhost',
     nativeCurrency: {
-      decimals: 18,
-      name: 'Acala USD',
+      decimals: 12,
+      name: 'Acala',
       symbol: 'ACA'
     },
     rpcUrls: ['/']

--- a/packages/web/src/hooks/use-sale.ts
+++ b/packages/web/src/hooks/use-sale.ts
@@ -105,12 +105,13 @@ export function useSale() {
 async function saleBuy(options: BuyPayload): Promise<Record<string, any>> {
   const { address, amount, contracts, signer } = options;
   const value = BigNumber.from(amount || '0');
-  const paymentAmount = utils.parseUnits(amount, 12);
 
   if (!contracts?.sale1 || value.lte(0)) {
     return;
   }
 
+  const aUsdDecimals = await contracts.aUsd.decimals();
+  const paymentAmount = utils.parseUnits(amount, aUsdDecimals);
   const allowance = await contracts.aUsd.allowance(
     address,
     contracts.sale1.address

--- a/yarn.lock
+++ b/yarn.lock
@@ -5644,15 +5644,15 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-date-fns@^2.28.0:
-  version "2.28.0"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.28.0.tgz#9570d656f5fc13143e50c975a3b6bbeb46cd08b2"
-  integrity sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==
-
 dayjs@^1.11.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.0.tgz#009bf7ef2e2ea2d5db2e6583d2d39a4b5061e805"
   integrity sha512-JLC809s6Y948/FuCZPm5IX8rRhQwOiyMb2TfVVQEixG7P8Lm/gt5S7yoQZmC8x1UehI9Pb7sksEt4xx14m+7Ug==
+
+dayjs@^1.11.1:
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.1.tgz#90b33a3dda3417258d48ad2771b415def6545eb0"
+  integrity sha512-ER7EjqVAMkRRsxNCC5YqJ9d9VQYuWdGt7aiH2qA5R5wt8ZmWaP2dLUSIK6y/kVzLMlmh1Tvu5xUf4M/wdGJ5KA==
 
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"


### PR DESCRIPTION
This PR fixes the unix timestamps from being converted to the browser timezone. In order to do it, date-fns was replaced by dayjs that within it's setup is forcing to work with UTC only, date-fns always casts any date to the local Date.
This also adds a loading state when we are fetching the app status based on the `saleStart`, `saleStart` and `vestingStart` dates.