### PR TITLE
Adding foundry for alternative faster tests

### DIFF
--- a/.github/workflows/contracts-foundry.yml
+++ b/.github/workflows/contracts-foundry.yml
@@ -1,0 +1,30 @@
+name: Contracts - Foundry Test Suite
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "*"
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  contracts-test-suite:
+    runs-on: ubuntu-latest
+
+    env:
+      FORCE_COLOR: true
+      REPORT_GAS: true
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
+
+      - run: forge test -vvv
+        working-directory: packages/contracts

--- a/.github/workflows/contracts-foundry.yml
+++ b/.github/workflows/contracts-foundry.yml
@@ -26,5 +26,23 @@ jobs:
         with:
           version: nightly
 
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - uses: actions/cache@v3
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - uses: actions/setup-node@v3.1.0
+        with:
+          node-version: "16"
+
+      - run: yarn install
+
       - run: forge test -vvv
         working-directory: packages/contracts

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "packages/contracts/lib/forge-std"]
+	path = packages/contracts/lib/forge-std
+	url = https://github.com/foundry-rs/forge-std

--- a/packages/contracts/foundry.toml
+++ b/packages/contracts/foundry.toml
@@ -1,0 +1,7 @@
+[default]
+
+# hardhat compatibility
+src = 'contracts'
+libs = ['lib', 'node_modules']
+
+# See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/packages/contracts/test/contracts/token/Citizend.d.sol
+++ b/packages/contracts/test/contracts/token/Citizend.d.sol
@@ -1,0 +1,35 @@
+pragma solidity ^0.8.0;
+
+import "forge-std/Test.sol";
+
+import {Citizend} from "../../../contracts/token/Citizend.sol";
+
+contract CitizendConstructorTest is Test {
+    address constant alice = address(0x1);
+
+    function testSetsCorrectParameters() public {
+        Citizend ctnd = new Citizend(alice);
+
+        require(_stringEq(ctnd.name(), "Citizend"));
+        require(_stringEq(ctnd.symbol(), "CTND"));
+    }
+
+    function testInitialMint() public {
+        Citizend ctnd = new Citizend(alice);
+
+        uint256 expectedSupply = 1e8 ether;
+        require(ctnd.totalSupply() == expectedSupply, "wrong supply");
+        require(
+            ctnd.balanceOf(address(this)) == expectedSupply,
+            "wrong balance"
+        );
+    }
+
+    function _stringEq(string memory s1, string memory s2)
+        internal
+        returns (bool)
+    {
+        return
+            keccak256(abi.encodePacked(s1)) == keccak256(abi.encodePacked(s2));
+    }
+}


### PR DESCRIPTION
This will allows us to write much faster solidity tests. And in some cases, easier to read too, due to lack of `await`, and easier timestamp jumps