### PR TITLE
Show 0 to be refunded after refund

### DIFF
--- a/packages/contracts/contracts/token/Sale.sol
+++ b/packages/contracts/contracts/token/Sale.sol
@@ -252,7 +252,12 @@ contract Sale is ISale, RisingTide, ERC165, AccessControl, ReentrancyGuard {
             return 0;
         }
 
-        uint256 uncapped = accounts[to].uncappedAllocation;
+        Account memory account = accounts[to];
+        if (account.refunded) {
+            return 0;
+        }
+
+        uint256 uncapped = account.uncappedAllocation;
         uint256 capped = allocation(to);
 
         return tokenToPaymentToken(uncapped - capped);

--- a/packages/contracts/test/contracts/token/Sale.ts
+++ b/packages/contracts/test/contracts/token/Sale.ts
@@ -261,6 +261,18 @@ describe("Sale", () => {
       expect(await sale.refundAmount(alice.address)).to.equal(0);
     });
 
+    it("is 0 if the amount has already been refunded", async () => {
+      const amount = parseUnits("10");
+
+      await sale.connect(alice).buy(amount.mul(2));
+
+      await goToTime(end);
+      await sale.setIndividualCap(amount, { gasLimit: 10000000 });
+      await sale.refund(alice.address);
+
+      expect(await sale.refundAmount(alice.address)).to.equal(0);
+    });
+
     it("is 0 if the individual cap is higher than the invested total", async () => {
       await sale.connect(alice).buy(parseUnits("1"));
       await sale.connect(bob).buy(parseUnits("9"));


### PR DESCRIPTION
Why:

* We were still showing the full amount of refund after it had been
  refunded. The refund action could not be triggered, but the UI would
  be wrong.

This change addresses the need by:

* Checking if that account has already been refunded and if true,
  returning 0 for the refundable amount, since there is only one refund
  possible.