### PR TITLE
Add Metamask new token handling mechanism

### DIFF
--- a/packages/web/src/components/core/link.tsx
+++ b/packages/web/src/components/core/link.tsx
@@ -9,10 +9,16 @@ import styled from 'styled-components';
  * Export `Link` styled component.
  */
 
-export const Link = styled.a.attrs({
-  rel: 'noopener',
-  target: '_blank'
-})`
+export const Link = styled.a.attrs(({ onClick }) =>
+  onClick
+    ? {
+        role: 'button'
+      }
+    : {
+        rel: 'noopener',
+        target: '_blank'
+      }
+)`
   ${textStyles.body}
 
   font-weight: bold;

--- a/packages/web/src/components/dashboard/project-info-card.tsx
+++ b/packages/web/src/components/dashboard/project-info-card.tsx
@@ -70,6 +70,18 @@ const Label = styled(Text).attrs({
 `;
 
 /**
+ * `Lead` styled component.
+ */
+
+const Lead = styled(Text).attrs({
+  as: 'p',
+  variant: 'body2'
+})`
+  position: relative;
+  top: -0.55rem;
+`;
+
+/**
  * `StyledSeparator` styled component.
  */
 
@@ -124,9 +136,7 @@ export function ProjectInfoCard(props: Props) {
       <div>
         <Label>{'Project'}</Label>
 
-        <Text as={'p'} variant={'body2'}>
-          {'Citizend token sale'}
-        </Text>
+        <Lead>{'Citizend token sale'}</Lead>
 
         {!!vestingStart && (
           <>

--- a/packages/web/src/components/dashboard/sale-form.tsx
+++ b/packages/web/src/components/dashboard/sale-form.tsx
@@ -15,7 +15,14 @@ import { media } from 'src/styles/breakpoints';
 import { useFractalKYCUrl } from 'src/hooks/use-kyc-url';
 import { useSaleBuy } from 'src/hooks/use-sale';
 import BigNumber from 'bignumber.js';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, {
+  ChangeEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState
+} from 'react';
+
 import styled from 'styled-components';
 
 /**
@@ -92,6 +99,14 @@ function getFieldError(amount: string) {
 }
 
 /**
+ * `getEventValue` util.
+ */
+
+function getEventValue(event: ChangeEvent<HTMLInputElement>) {
+  return event.target.value.replace(/[^0-9.]/g, '');
+}
+
+/**
  * Export `SaleForm` component.
  */
 
@@ -102,8 +117,21 @@ export function SaleForm(props: Props) {
   const fieldError = getFieldError(amount);
   const kycUrl = useFractalKYCUrl();
   const handleOnChange = useCallback(event => {
-    setAmount(event.target.value.replace(/[^0-9]/g, ''));
+    setAmount(getEventValue(event));
   }, []);
+
+  const handleTokenOnChange = useCallback(
+    event => {
+      const value = getEventValue(event);
+      const convertedValue = new BigNumber(tokenPrice)
+        .times(value || 0)
+        .decimalPlaces(4)
+        .toString();
+
+      setAmount(convertedValue);
+    },
+    [tokenPrice]
+  );
 
   const convertedAmount = useMemo(() => {
     return new BigNumber(amount || 0)
@@ -149,9 +177,9 @@ export function SaleForm(props: Props) {
           />
 
           <InputField
-            disabled
             label={'CTND amount'}
             name={'converted'}
+            onChange={handleTokenOnChange}
             placeholder={0}
             suffix={'CTND'}
             value={convertedAmount || 0}

--- a/packages/web/src/components/screens/connect.tsx
+++ b/packages/web/src/components/screens/connect.tsx
@@ -208,18 +208,16 @@ export function ConnectScreen() {
   );
 
   const handleNetworkChange = useCallback(async () => {
-    if (!(window as any)?.ethereum) {
+    if (!window?.ethereum) {
       toast.error('We could not find any library for using web3.');
 
       return;
     }
 
-    const { ethereum } = window as any;
-
     try {
       setIsOpen(false);
 
-      await ethereum.request({
+      await window.ethereum.request({
         method: 'wallet_switchEthereumChain',
         params: [{ chainId: chainConfig.chainId }]
       });
@@ -237,7 +235,7 @@ export function ConnectScreen() {
       }
 
       try {
-        await ethereum.request({
+        await window.ethereum.request({
           method: 'wallet_addEthereumChain',
           params: [chainConfig]
         });

--- a/packages/web/src/components/vesting/index.tsx
+++ b/packages/web/src/components/vesting/index.tsx
@@ -33,8 +33,8 @@ const Grid = styled.section`
 
 export function Vesting() {
   const vestingState = useVesting();
-  const { isPending: isRefundLoading, run: refund } = useRefund();
-  const { isPending: isClaimLoading, run: claim } = useClaim();
+  const refund = useRefund();
+  const claim = useClaim();
   const { claimable, refundable, tokens, totalClaimed } = useMemo(
     () => ({
       claimable: formatCurrency(vestingState.claimable, currencyConfig.ctnd),
@@ -57,30 +57,36 @@ export function Vesting() {
       />
 
       <ClaimActionCard
-        isDisabled={!vestingState.claimEnabled}
-        onClick={claim}
+        isConfirming={claim.isConfirming}
+        isDisabled={!!vestingState.claimEnabled}
+        onClick={() => {
+          claim.run();
+        }}
         title={'Available to claim'}
         value={claimable}
       />
 
       <LoadingModal
         amount={claimable}
-        isOpen={isClaimLoading}
+        isOpen={claim.isPending}
         label={'Claimed value'}
       />
 
       {vestingState.refundEnabled && (
         <>
           <ClaimActionCard
-            isDisabled={!vestingState.refundEnabled}
-            onClick={refund}
+            isConfirming={refund.isConfirming}
+            isDisabled={!!vestingState.refundEnabled}
+            onClick={() => {
+              refund.run();
+            }}
             title={'Refund available'}
             value={refundable}
           />
 
           <LoadingModal
             amount={refundable}
-            isOpen={isRefundLoading}
+            isOpen={refund.isPending}
             label={'Refund after cap calculations'}
           />
         </>

--- a/packages/web/src/components/vesting/info-card.tsx
+++ b/packages/web/src/components/vesting/info-card.tsx
@@ -2,10 +2,13 @@
  * Module dependencies.
  */
 
+import { Link } from 'src/components/core/link';
 import { StyledCard, Title } from './styles';
 import { Text } from 'src/components/core/text';
 import { media } from 'src/styles/breakpoints';
-import React from 'react';
+import { toast } from 'react-toastify';
+import { useContracts } from 'src/context/contracts';
+import React, { useCallback } from 'react';
 import styled from 'styled-components';
 
 /**
@@ -47,18 +50,52 @@ const FlexRow = styled.div`
 
 export function InfoCard(props: Props) {
   const { nextRelease, tokens, totalClaimed } = props;
+  const contracts = useContracts();
+  const assetAddress = contracts?.citizend.address;
+  const addTokenToMetamask = useCallback(async () => {
+    if (!window?.ethereum) {
+      toast.error('We could not find any library for using web3.');
+
+      return;
+    }
+
+    try {
+      await window.ethereum.request({
+        method: 'wallet_watchAsset',
+        params: {
+          options: {
+            address: assetAddress,
+            decimals: 18,
+            symbol: 'CTND'
+          },
+          type: 'ERC20'
+        }
+      });
+    } catch (error) {
+      toast.error(
+        'We could not add our token to your metamask. Try adding it manually or contact support.'
+      );
+    }
+  }, [assetAddress]);
 
   return (
     <StyledCard>
-      <div>
-        <Title>{'My tokens'}</Title>
-
-        <Text as={'p'} noMargin variant={'body2'}>
-          {tokens}
-        </Text>
-      </div>
-
       <Grid>
+        <div>
+          <Title>{'My tokens'}</Title>
+
+          <Text as={'p'} noMargin variant={'body2'}>
+            {tokens}
+          </Text>
+        </div>
+
+        <Link
+          onClick={addTokenToMetamask}
+          style={{ alignSelf: 'flex-end', margin: 0 }}
+        >
+          {'Add token to metamask'}
+        </Link>
+
         <FlexRow>
           <Text variant={'label'}>{'Total Claimed'}</Text>
           <Text noMargin>{totalClaimed}</Text>

--- a/packages/web/src/components/vesting/styles.tsx
+++ b/packages/web/src/components/vesting/styles.tsx
@@ -6,7 +6,7 @@ import { Button } from 'src/components/core/button';
 import { Card } from 'src/components/core/card';
 import { Text } from 'src/components/core/text';
 import React from 'react';
-import styled from 'styled-components';
+import styled, { keyframes } from 'styled-components';
 
 /**
  * `Props` type.
@@ -15,6 +15,7 @@ import styled from 'styled-components';
 type Props = {
   title: string;
   value: string;
+  isConfirming: boolean;
   isDisabled?: boolean;
   onClick: () => void;
 };
@@ -42,11 +43,46 @@ export const StyledCard = styled(Card)`
 `;
 
 /**
+ * `dots` keyframes.
+ */
+
+const dots = keyframes`
+  0%, 20% {
+    color: rgba(0,0,0,0);
+    text-shadow: .25em 0 0 rgba(0,0,0,0), .5em 0 0 rgba(0,0,0,0);
+  }
+
+  40% {
+    color: white;
+    text-shadow: .25em 0 0 rgba(0,0,0,0), .5em 0 0 rgba(0,0,0,0);
+  }
+
+  60% {
+    text-shadow: .25em 0 0 white, .5em 0 0 rgba(0,0,0,0);
+  }
+
+  80%, 100% {
+    text-shadow: .25em 0 0 white, .5em 0 0 white;
+  }
+`;
+
+/**
+ * `Dots` styled component.
+ */
+
+const Dots = styled.span`
+  &::after {
+    animation: ${dots} 1.5s steps(5, end) infinite;
+    content: ' .';
+  }
+`;
+
+/**
  * Export `ClaimActionCard` component.
  */
 
 export function ClaimActionCard(props: Props) {
-  const { isDisabled, onClick, title, value } = props;
+  const { isConfirming, isDisabled, onClick, title, value } = props;
 
   return (
     <StyledCard>
@@ -57,7 +93,7 @@ export function ClaimActionCard(props: Props) {
       </div>
 
       <Button disabled={isDisabled} onClick={isDisabled ? undefined : onClick}>
-        {'Claim'}
+        {!isConfirming ? 'Claim' : <Dots>{'Processing'}</Dots>}
       </Button>
     </StyledCard>
   );

--- a/packages/web/src/hooks/use-vesting.ts
+++ b/packages/web/src/hooks/use-vesting.ts
@@ -103,20 +103,37 @@ export function useVesting() {
  */
 
 export function useClaim(options?: AsyncOptions<Record<string, any>>) {
+  const [isConfirming, setIsConfirming] = useState<boolean>(false);
   const { account, library } = useWeb3React<Web3Provider>();
   const signer = library?.getSigner ? library.getSigner(0) : undefined;
   const contracts = useContracts();
-
-  return useAsync({
+  const state = useAsync({
     onReject: onBlockchainReject,
     onResolve: onBlockchainResolve(),
     ...options,
-    deferFn: () => {
+    deferFn: async () => {
+      setIsConfirming(true);
+
       if (!!contracts?.vesting && !!account) {
-        return contracts.vesting.connect(signer).claim(account);
+        try {
+          const tx = await contracts.vesting.connect(signer).claim(account);
+
+          tx.finally(() => {
+            setIsConfirming(false);
+          });
+
+          return tx;
+        } finally {
+          setIsConfirming(false);
+        }
       }
     }
   });
+
+  return {
+    ...state,
+    isConfirming
+  };
 }
 
 /**
@@ -124,18 +141,35 @@ export function useClaim(options?: AsyncOptions<Record<string, any>>) {
  */
 
 export function useRefund(options?: AsyncOptions<Record<string, any>>) {
+  const [isConfirming, setIsConfirming] = useState<boolean>(false);
   const { account, library } = useWeb3React<Web3Provider>();
   const signer = library?.getSigner ? library.getSigner(0) : undefined;
   const contracts = useContracts();
-
-  return useAsync({
+  const state = useAsync({
     onReject: onBlockchainReject,
     onResolve: onBlockchainResolve(),
     ...options,
-    deferFn: () => {
+    deferFn: async () => {
+      setIsConfirming(true);
+
       if (!!contracts?.vesting && !!account) {
-        return contracts.vesting.connect(signer).refund(account);
+        try {
+          const tx = await contracts.vesting.connect(signer).refund(account);
+
+          tx.finally(() => {
+            setIsConfirming(false);
+          });
+
+          return tx;
+        } finally {
+          setIsConfirming(false);
+        }
       }
     }
   });
+
+  return {
+    ...state,
+    isConfirming
+  };
 }

--- a/packages/web/src/types/global.d.ts
+++ b/packages/web/src/types/global.d.ts
@@ -1,3 +1,18 @@
+/**
+ * Module dependencies.
+ */
+
+import { MetaMaskInpageProvider } from '@metamask/providers';
+
+/**
+ * Modules declarations.
+ */
+
 declare module '*.svg';
 declare module '*.css';
 declare module '*.json';
+declare global {
+  interface Window {
+    ethereum: MetaMaskInpageProvider;
+  }
+}


### PR DESCRIPTION
This PR adds a link to the Vesting state that allows users to **add the token** to _metamask_.

**This PR also:**
- Adds support for Sale form input sync between aUSD and CTND values.
- Adds loading state when waiting for the claim/refund to be confirmed.

Refs #155, #159.