### PR TITLE
Update wagmi config to include React plugin

### DIFF
--- a/packages/contracts/contracts/discovery/pools/Pool.sol
+++ b/packages/contracts/contracts/discovery/pools/Pool.sol
@@ -42,7 +42,7 @@ abstract contract Pool is IPool, RisingTide {
     address public immutable investmentToken;
 
     /// total unique investors
-    uint256 public _investorCount;
+    uint256 _investorCount;
 
     mapping(address => Investor) investors;
 

--- a/packages/contracts/contracts/token/Sale.sol
+++ b/packages/contracts/contracts/token/Sale.sol
@@ -78,7 +78,7 @@ contract Sale is ISale, RisingTide, ERC165, AccessControl, ReentrancyGuard {
     mapping(uint256 => address) investorByIndex;
 
     /// total unique investors
-    uint256 public _investorCount;
+    uint256 _investorCount;
 
     /// How many tokens have been allocated, before cap calculation
     uint256 public totalUncappedAllocations;

--- a/packages/contracts/wagmi.config.ts
+++ b/packages/contracts/wagmi.config.ts
@@ -6,10 +6,8 @@ export default defineConfig({
   plugins: [
     foundry({
       project: "./",
-      exclude: [
-        "MockERC20.sol",
-      ],
+      exclude: ["MockERC20.sol"],
     }),
     react(),
-  ]
+  ],
 });

--- a/packages/contracts/wagmi.config.ts
+++ b/packages/contracts/wagmi.config.ts
@@ -1,25 +1,15 @@
 import { defineConfig } from "@wagmi/cli";
-import { foundry } from "@wagmi/cli/plugins";
+import { foundry, react } from "@wagmi/cli/plugins";
 
 export default defineConfig({
   out: "../web/wagmi.generated.ts",
-  contracts: [],
   plugins: [
     foundry({
+      project: "./",
       exclude: [
-        // We have a MockERC20.sol contract that is conflicting with the MockERC20 contract from forge
-        // Until we refactor, we need to ignore it for the wagmi compilation to succeed
         "MockERC20.sol",
       ],
-      project: "./",
-      deployments: {
-        Citizend: {
-          31337: "0x5fbdb2315678afecb367f032d93f642f64180aa3",
-        },
-        Staking: {
-          31337: "0xe7f1725e7734ce288f8367e1bb143e90bb3f0512",
-        },
-      },
     }),
-  ],
+    react(),
+  ]
 });


### PR DESCRIPTION
Why:
* Wagmi can generate React Hooks that allow calling functions from the
  contracts

How:
* Updating `wagmi.config.ts` to include the React plugin
* Making `_investorCount` varible in the `Pool` and `Sale` contracts
  private to prevent an error when generating the hooks. Since we
  already have a read function that returns the value, `wagmi` was
  trying to generate two hooks with the same name and causing an error
