### PR TITLE
Fixing Justfile command for reloading anvil

### DIFF
--- a/packages/contracts/Justfile
+++ b/packages/contracts/Justfile
@@ -63,6 +63,7 @@ wagmi:
 # restart `just eth` when contracts change
 eth-watch:
   watchexec \
+    --project-origin . \
     --watch contracts \
     --watch test \
     --watch foundry.toml \


### PR DESCRIPTION
Why:
* This was not working correctly, possibly due to this
  [bug](https://github.com/watchexec/watchexec/issues/765)

How:
* Adding an extra flag to `watchexec` so it correctly starts the process
