### PR TITLE
Remove Fractal Registry from Sale and add minContribution

### DIFF
--- a/packages/contracts/Justfile
+++ b/packages/contracts/Justfile
@@ -44,7 +44,7 @@ eth:
   #!/bin/bash
   killall -9 anvil
   just build-contracts
-  # just test
+  just test
   sleep 0.2 && just eth-deploy &
   just wagmi &
   anvil --code-size-limit 100000 --host 0.0.0.0

--- a/packages/contracts/contracts/test/MockERC20.sol
+++ b/packages/contracts/contracts/test/MockERC20.sol
@@ -14,7 +14,6 @@ contract MockERC20 is ERC20 {
         string memory _symbol,
         uint8 __decimals
     ) ERC20(_name, _symbol) {
-        _mint(msg.sender, 1e9 ether);
         _decimals = __decimals;
     }
 

--- a/packages/contracts/script/DevDeploy.s.sol
+++ b/packages/contracts/script/DevDeploy.s.sol
@@ -4,22 +4,29 @@ pragma solidity ^0.8.20;
 import {Script} from "lib/forge-std/src/Script.sol";
 
 import {Citizend} from "contracts/token/Citizend.sol";
+import {Sale} from "contracts/token/Sale.sol";
+
+import {MockERC20} from "contracts/test/MockERC20.sol";
+
 import {Controller} from "contracts/discovery/Controller.sol";
 import {Staking} from "contracts/discovery/Staking.sol";
 import {Project} from "contracts/discovery/Project.sol";
 
 contract DevDeployScript is Script {
-    address alice = address(0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266);
-    address bob = address(0x70997970C51812dc3A010C7d01b50e0d17dc79C8);
-    address carol = address(0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266);
+    address owner = address(0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266);
+    address alice = address(0x70997970C51812dc3A010C7d01b50e0d17dc79C8);
+    address bob = address(0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC);
 
     address[] testAccounts;
 
+    uint256 start;
+    uint256 end;
+
     function setUp() public {
         testAccounts = new address[](3);
-        testAccounts[0] = alice;
-        testAccounts[1] = bob;
-        testAccounts[2] = carol;
+        testAccounts[0] = owner;
+        testAccounts[1] = alice;
+        testAccounts[2] = bob;
     }
 
     function run() public {
@@ -27,30 +34,25 @@ contract DevDeployScript is Script {
 
         bytes32 merkleRoot = 0xa5c09e2a9128afef7246a5900cfe02c4bd2cfcac8ac4286f0159a699c8455a49;
 
-        Citizend citizend = new Citizend(alice);
-        Staking staking = new Staking(address(citizend));
+        // Citizend citizend = new Citizend(owner);
+        // Staking staking = new Staking(address(citizend));
+        //
+        // Controller controller = new Controller(address(staking), address(citizend), merkleRoot);
+        // Project project = new Project("token sale project", address(citizend), 1000, 1, address(0), merkleRoot);
 
-        Controller controller = new Controller(
-            address(staking),
-            address(citizend),
-            merkleRoot
-        );
+        start = vm.getBlockTimestamp();
+        end = start + 60 * 60 * 24;
 
-        Project project = new Project(
-            "token sale project",
-            address(citizend),
-            1000,
-            1,
-            address(0),
-            merkleRoot
-        );
+        MockERC20 token = new MockERC20("USDC", "USDC", 18);
+        Sale sale = new Sale(address(token), 1 ** 18, start, end, 1000);
+
+        bool success = token.approve(address(sale), 1000 ether);
+        require(success, "approve failed");
 
         for (uint256 i; i < testAccounts.length; i++) {
             address addr = testAccounts[i];
-            (bool success, ) = addr.call{value: 10 ether}("");
-            require(success, "transfer failed");
+            token.mint(testAccounts[i], 1000 ether);
         }
-
         vm.stopBroadcast();
     }
 }

--- a/packages/contracts/test/contracts/token/Sale.d.sol
+++ b/packages/contracts/test/contracts/token/Sale.d.sol
@@ -1,0 +1,81 @@
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+
+import {Sale} from "../../../contracts/token/Sale.sol";
+import {MockERC20} from "../../../contracts/test/MockERC20.sol";
+
+contract SaleTest is Test {
+    Sale sale;
+    MockERC20 paymentToken;
+    uint256 start;
+    uint256 end;
+
+    address owner = 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266;
+    address alice = 0x70997970C51812dc3A010C7d01b50e0d17dc79C8;
+    address bob = 0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC;
+
+    event Purchase(
+        address indexed from,
+        uint256 paymentTokenAmount,
+        uint256 tokenAmount
+    );
+
+    function setUp() public {
+        vm.startPrank(owner);
+
+        start = vm.getBlockTimestamp();
+        end = start + 60 * 60 * 24;
+
+        paymentToken = new MockERC20("USDC", "USDC", 18);
+        sale = new Sale(address(paymentToken), 1 ** 18, start, end, 100);
+
+        vm.stopPrank();
+
+        vm.startPrank(alice);
+
+        paymentToken.mint(alice, 100 ether);
+        paymentToken.approve(address(sale), 100 ether);
+
+        vm.stopPrank();
+    }
+
+    function testConstructor() public {
+        require(sale.paymentToken() == address(paymentToken));
+        require(sale.rate() == 1);
+        require(sale.start() == start);
+        require(sale.end() == end);
+        require(sale.hasRole(sale.DEFAULT_ADMIN_ROLE(), owner));
+        require(sale.hasRole(sale.CAP_VALIDATOR_ROLE(), owner));
+    }
+
+    function testBuy() public {
+        vm.startPrank(alice);
+        vm.expectEmit();
+
+        emit Purchase(address(alice), 1, 1 ether);
+
+        sale.buy(1 ether);
+
+        require(sale.risingTide_totalAllocatedUncapped() == 1 ether);
+
+        vm.stopPrank();
+    }
+
+    function testBuyBelowMinimum() public {
+        vm.prank(owner);
+
+        sale.setMinContribution(2 ether);
+
+        vm.startPrank(alice);
+
+        vm.expectRevert(bytes("can't be below minimum"));
+        sale.buy(1 ether);
+
+        sale.buy(2 ether);
+
+        require(sale.risingTide_totalAllocatedUncapped() == 2 ether);
+
+        vm.stopPrank();
+    }
+}


### PR DESCRIPTION
Why:
* We are using idOS instead for KYC verification and we no longer need
  the Fractal Registry contract in the Sale
* We want to have a minimum contribution value for the token buy and be
  able to update it

How:
* Removing the `registry` ocurrences from the `Sale` contract
* Adding a `Sale.d.sol` test to test the `Sale` contrat using Foundry
* Updating the `MockERC20.sol` contract to no longer mint tokens for the
  deployer
* Updating the `DevDeploy.s.sol` script to deploy the Sale contract
