### PR TITLE
Add min and max range for Sale and deploy script

### DIFF
--- a/packages/contracts/contracts/token/Sale.sol
+++ b/packages/contracts/contracts/token/Sale.sol
@@ -111,7 +111,10 @@ contract Sale is ISale, RisingTide, ERC165, AccessControl, ReentrancyGuard {
         require(_end > _start, "end must be after start");
         require(_totalTokensForSale > 0, "total cannot be 0");
         require(_minTarget > 0, "_minTarget cannot be 0");
-        require(_maxTarget > _minTarget, "_maxTarget cannot be lower than _minTarget");
+        require(
+            _maxTarget > _minTarget,
+            "_maxTarget cannot be lower than _minTarget"
+        );
 
         paymentToken = _paymentToken;
         rate = _rate;

--- a/packages/contracts/contracts/token/Sale.sol
+++ b/packages/contracts/contracts/token/Sale.sol
@@ -73,6 +73,9 @@ contract Sale is ISale, RisingTide, ERC165, AccessControl, ReentrancyGuard {
 
     uint256 public immutable totalTokensForSale;
 
+    uint256 public immutable minTarget;
+    uint256 public immutable maxTarget;
+
     /// Token allocations committed by each buyer
     mapping(address => Account) accounts;
 
@@ -98,19 +101,25 @@ contract Sale is ISale, RisingTide, ERC165, AccessControl, ReentrancyGuard {
         uint256 _rate,
         uint256 _start,
         uint256 _end,
-        uint256 _totalTokensForSale
+        uint256 _totalTokensForSale,
+        uint256 _minTarget,
+        uint256 _maxTarget
     ) {
         require(_rate > 0, "can't be zero");
         require(_paymentToken != address(0), "can't be zero");
         require(_start > 0, "can't be zero");
         require(_end > _start, "end must be after start");
         require(_totalTokensForSale > 0, "total cannot be 0");
+        require(_minTarget > 0, "_minTarget cannot be 0");
+        require(_maxTarget > _minTarget, "_maxTarget cannot be lower than _minTarget");
 
         paymentToken = _paymentToken;
         rate = _rate;
         start = _start;
         end = _end;
         totalTokensForSale = _totalTokensForSale;
+        minTarget = _minTarget;
+        maxTarget = _maxTarget;
 
         _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
         _grantRole(CAP_VALIDATOR_ROLE, msg.sender);

--- a/packages/contracts/foundry.toml
+++ b/packages/contracts/foundry.toml
@@ -4,3 +4,9 @@ out = 'out'
 libs = ['lib', 'node_modules']
 test = 'test'
 cache_path  = 'cache_forge'
+
+[rpc_endpoints]
+sepolia = "${ETH_RPC_URL}"
+
+[etherscan]
+sepolia = { key = "${ETHERSCAN_API_KEY}"}

--- a/packages/contracts/script/Deploy.s.sol
+++ b/packages/contracts/script/Deploy.s.sol
@@ -7,15 +7,23 @@ import {MockERC20} from "contracts/test/MockERC20.sol";
 import {Sale} from "contracts/token/Sale.sol";
 
 contract DeployScript is Script {
- function run() public {
-   vm.startBroadcast();
+    function run() public {
+        vm.startBroadcast();
 
-   uint start = vm.unixTime();
-   uint end = start + 60 * 60 * 24 * 7;
+        uint start = vm.unixTime();
+        uint end = start + 60 * 60 * 24 * 7;
 
-   MockERC20 token = new MockERC20("USDC", "USDC", 18);
-   Sale sale = new Sale(address(token), 1 ** 18, start, end, 1000, 1000000, 2000000);
+        MockERC20 token = new MockERC20("USDC", "USDC", 18);
+        Sale sale = new Sale(
+            address(token),
+            1 ** 18,
+            start,
+            end,
+            1000,
+            1000000,
+            2000000
+        );
 
-   vm.stopBroadcast();
- }
+        vm.stopBroadcast();
+    }
 }

--- a/packages/contracts/script/Deploy.s.sol
+++ b/packages/contracts/script/Deploy.s.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.20;
+
+import {Script} from "lib/forge-std/src/Script.sol";
+
+import {MockERC20} from "contracts/test/MockERC20.sol";
+import {Sale} from "contracts/token/Sale.sol";
+
+contract DeployScript is Script {
+ function run() public {
+   vm.startBroadcast();
+
+   uint start = vm.unixTime();
+   uint end = start + 60 * 60 * 24 * 7;
+
+   MockERC20 token = new MockERC20("USDC", "USDC", 18);
+   Sale sale = new Sale(address(token), 1 ** 18, start, end, 1000, 1000000, 2000000);
+
+   vm.stopBroadcast();
+ }
+}

--- a/packages/contracts/script/DevDeploy.s.sol
+++ b/packages/contracts/script/DevDeploy.s.sol
@@ -44,7 +44,7 @@ contract DevDeployScript is Script {
         end = start + 60 * 60 * 24;
 
         MockERC20 token = new MockERC20("USDC", "USDC", 18);
-        Sale sale = new Sale(address(token), 1 ** 18, start, end, 1000);
+        Sale sale = new Sale(address(token), 1 ** 18, start, end, 1000, 1000000, 2000000);
 
         bool success = token.approve(address(sale), 1000 ether);
         require(success, "approve failed");

--- a/packages/contracts/script/DevDeploy.s.sol
+++ b/packages/contracts/script/DevDeploy.s.sol
@@ -44,7 +44,15 @@ contract DevDeployScript is Script {
         end = start + 60 * 60 * 24;
 
         MockERC20 token = new MockERC20("USDC", "USDC", 18);
-        Sale sale = new Sale(address(token), 1 ** 18, start, end, 1000, 1000000, 2000000);
+        Sale sale = new Sale(
+            address(token),
+            1 ** 18,
+            start,
+            end,
+            1000,
+            1000000,
+            2000000
+        );
 
         bool success = token.approve(address(sale), 1000 ether);
         require(success, "approve failed");

--- a/packages/contracts/script/generateMerkleTree.ts
+++ b/packages/contracts/script/generateMerkleTree.ts
@@ -40,7 +40,7 @@ async function main(address: string) {
   const key = [address];
   console.log(`\n\nProof for ${key}:`);
   console.log(
-    merkleTree.getHexProof(keccak256(encodePacked(["address"], key))),
+    merkleTree.getHexProof(keccak256(encodePacked(["address"], key)))
   );
 }
 

--- a/packages/contracts/script/generateMerkleTree.ts
+++ b/packages/contracts/script/generateMerkleTree.ts
@@ -40,7 +40,7 @@ async function main(address: string) {
   const key = [address];
   console.log(`\n\nProof for ${key}:`);
   console.log(
-    merkleTree.getHexProof(keccak256(encodePacked(["address"], key)))
+    merkleTree.getHexProof(keccak256(encodePacked(["address"], key))),
   );
 }
 

--- a/packages/contracts/test/contracts/token/Sale.d.sol
+++ b/packages/contracts/test/contracts/token/Sale.d.sol
@@ -28,7 +28,7 @@ contract SaleTest is Test {
         end = start + 60 * 60 * 24;
 
         paymentToken = new MockERC20("USDC", "USDC", 18);
-        sale = new Sale(address(paymentToken), 1 ** 18, start, end, 100);
+        sale = new Sale(address(paymentToken), 1 ** 18, start, end, 100, 1000000, 2000000);
 
         vm.stopPrank();
 

--- a/packages/contracts/test/contracts/token/Sale.d.sol
+++ b/packages/contracts/test/contracts/token/Sale.d.sol
@@ -28,7 +28,15 @@ contract SaleTest is Test {
         end = start + 60 * 60 * 24;
 
         paymentToken = new MockERC20("USDC", "USDC", 18);
-        sale = new Sale(address(paymentToken), 1 ** 18, start, end, 100, 1000000, 2000000);
+        sale = new Sale(
+            address(paymentToken),
+            1 ** 18,
+            start,
+            end,
+            100,
+            1000000,
+            2000000
+        );
 
         vm.stopPrank();
 


### PR DESCRIPTION
Why:
* The Sale contract needs to have a minimum and maximum amount to raise.
  When the maximum is reached, Rising Tide triggers for the final time
* We want to have a mock Sale contract deployed in Sepolia so we can
  start testing the integration with the UI

How:
* Adding the `minTarget` and `maxTarget` variables to the Sale contract
* Adding a `Deploy.s.sol` script to deploy mock Sale and MockERC20 contracts
* Updating the tests and the foundry config
