### PR TITLE
Add claim to Sale

### DIFF
--- a/packages/contracts/contracts/test/MockSale.sol
+++ b/packages/contracts/contracts/test/MockSale.sol
@@ -16,6 +16,7 @@ contract MockSale is ISale, ERC165 {
     mapping(address => uint256) public override(ISale) refundAmount;
     mapping(string => uint256) public calls;
 
+    address public token;
     address public paymentToken;
 
     function paymentTokenToToken(

--- a/packages/contracts/contracts/token/ISale.sol
+++ b/packages/contracts/contracts/token/ISale.sol
@@ -2,7 +2,10 @@
 pragma solidity ^0.8.20;
 
 interface ISale {
-    /// The $aUSD token
+    /// The $CTND token
+    function token() external view returns (address);
+
+    /// The $USDC token
     function paymentToken() external view returns (address);
 
     /// How many $CTND will be received for the given payment amount

--- a/packages/contracts/script/Deploy.s.sol
+++ b/packages/contracts/script/Deploy.s.sol
@@ -12,8 +12,8 @@ contract DeployScript is Script {
 
         uint256 start = vm.unixTime();
         uint256 end = start + 60 * 60 * 24 * 7;
-        uint256 startRegistration = 1714089600;
-        uint256 endRegistration = 1714694400;
+        uint256 startRegistration = 1714089600000;
+        uint256 endRegistration = 1714694400000;
 
         MockERC20 token = new MockERC20("USDC", "USDC", 18);
         Sale sale = new Sale(

--- a/packages/contracts/script/DevDeploy.s.sol
+++ b/packages/contracts/script/DevDeploy.s.sol
@@ -36,8 +36,8 @@ contract DevDeployScript is Script {
 
         bytes32 merkleRoot = 0xa5c09e2a9128afef7246a5900cfe02c4bd2cfcac8ac4286f0159a699c8455a49;
 
-        startRegistration = 1714089600;
-        endRegistration = 1714694400;
+        startRegistration = 1714089600000;
+        endRegistration = 1714694400000;
 
         start = vm.getBlockTimestamp();
         end = start + 60 * 60 * 24;
@@ -49,12 +49,14 @@ contract DevDeployScript is Script {
             1 ** 18,
             start,
             end,
-            1000,
+            100000000000000000000,
             1000000,
             2000000,
             startRegistration,
             endRegistration
         );
+
+        bool sucesss = citizend.transfer(address(sale), 1000 ether);
 
         bool success = token.approve(address(sale), 1000 ether);
         require(success, "approve failed");

--- a/packages/web-app/wagmi.generated.ts
+++ b/packages/web-app/wagmi.generated.ts
@@ -3997,6 +3997,13 @@ export const iSaleAbi = [
   },
   {
     type: 'function',
+    inputs: [],
+    name: 'token',
+    outputs: [{ name: '', internalType: 'address', type: 'address' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
     inputs: [
       { name: '_tokenAmount', internalType: 'uint256', type: 'uint256' },
     ],
@@ -4552,6 +4559,13 @@ export const mockSaleAbi = [
     name: 'test_addRefund',
     outputs: [],
     stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    inputs: [],
+    name: 'token',
+    outputs: [{ name: '', internalType: 'address', type: 'address' }],
+    stateMutability: 'view',
   },
   {
     type: 'function',
@@ -5942,6 +5956,13 @@ export const saleAbi = [
   {
     type: 'function',
     inputs: [],
+    name: 'claim',
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    inputs: [],
     name: 'end',
     outputs: [{ name: '', internalType: 'uint256', type: 'uint256' }],
     stateMutability: 'view',
@@ -6180,6 +6201,13 @@ export const saleAbi = [
   },
   {
     type: 'function',
+    inputs: [{ name: '_token', internalType: 'address', type: 'address' }],
+    name: 'setToken',
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
     inputs: [],
     name: 'start',
     outputs: [{ name: '', internalType: 'uint256', type: 'uint256' }],
@@ -6197,6 +6225,13 @@ export const saleAbi = [
     inputs: [{ name: 'interfaceId', internalType: 'bytes4', type: 'bytes4' }],
     name: 'supportsInterface',
     outputs: [{ name: '', internalType: 'bool', type: 'bool' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [],
+    name: 'token',
+    outputs: [{ name: '', internalType: 'address', type: 'address' }],
     stateMutability: 'view',
   },
   {
@@ -6242,6 +6277,20 @@ export const saleAbi = [
     name: 'withdrawn',
     outputs: [{ name: '', internalType: 'bool', type: 'bool' }],
     stateMutability: 'view',
+  },
+  {
+    type: 'event',
+    anonymous: false,
+    inputs: [
+      { name: 'to', internalType: 'address', type: 'address', indexed: true },
+      {
+        name: 'tokenAmount',
+        internalType: 'uint256',
+        type: 'uint256',
+        indexed: false,
+      },
+    ],
+    name: 'Claim',
   },
   {
     type: 'event',
@@ -6551,6 +6600,13 @@ export const saleTestAbi = [
   {
     type: 'function',
     inputs: [],
+    name: 'testBuyAndClaim',
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    inputs: [],
     name: 'testBuyBelowMinimum',
     outputs: [],
     stateMutability: 'nonpayable',
@@ -6561,6 +6617,20 @@ export const saleTestAbi = [
     name: 'testConstructor',
     outputs: [],
     stateMutability: 'nonpayable',
+  },
+  {
+    type: 'event',
+    anonymous: false,
+    inputs: [
+      { name: 'to', internalType: 'address', type: 'address', indexed: true },
+      {
+        name: 'tokenAmount',
+        internalType: 'uint256',
+        type: 'uint256',
+        indexed: false,
+      },
+    ],
+    name: 'Claim',
   },
   {
     type: 'event',
@@ -17399,6 +17469,14 @@ export const useReadISaleRefundAmount = /*#__PURE__*/ createUseReadContract({
 })
 
 /**
+ * Wraps __{@link useReadContract}__ with `abi` set to __{@link iSaleAbi}__ and `functionName` set to `"token"`
+ */
+export const useReadISaleToken = /*#__PURE__*/ createUseReadContract({
+  abi: iSaleAbi,
+  functionName: 'token',
+})
+
+/**
  * Wraps __{@link useReadContract}__ with `abi` set to __{@link iSaleAbi}__ and `functionName` set to `"tokenToPaymentToken"`
  */
 export const useReadISaleTokenToPaymentToken =
@@ -18206,6 +18284,14 @@ export const useReadMockSaleSupportsInterface =
 export const useReadMockSaleTestCalled = /*#__PURE__*/ createUseReadContract({
   abi: mockSaleAbi,
   functionName: 'test_Called',
+})
+
+/**
+ * Wraps __{@link useReadContract}__ with `abi` set to __{@link mockSaleAbi}__ and `functionName` set to `"token"`
+ */
+export const useReadMockSaleToken = /*#__PURE__*/ createUseReadContract({
+  abi: mockSaleAbi,
+  functionName: 'token',
 })
 
 /**
@@ -20022,6 +20108,14 @@ export const useReadSaleSupportsInterface = /*#__PURE__*/ createUseReadContract(
 )
 
 /**
+ * Wraps __{@link useReadContract}__ with `abi` set to __{@link saleAbi}__ and `functionName` set to `"token"`
+ */
+export const useReadSaleToken = /*#__PURE__*/ createUseReadContract({
+  abi: saleAbi,
+  functionName: 'token',
+})
+
+/**
  * Wraps __{@link useReadContract}__ with `abi` set to __{@link saleAbi}__ and `functionName` set to `"tokenToPaymentToken"`
  */
 export const useReadSaleTokenToPaymentToken =
@@ -20078,6 +20172,14 @@ export const useWriteSale = /*#__PURE__*/ createUseWriteContract({
 export const useWriteSaleBuy = /*#__PURE__*/ createUseWriteContract({
   abi: saleAbi,
   functionName: 'buy',
+})
+
+/**
+ * Wraps __{@link useWriteContract}__ with `abi` set to __{@link saleAbi}__ and `functionName` set to `"claim"`
+ */
+export const useWriteSaleClaim = /*#__PURE__*/ createUseWriteContract({
+  abi: saleAbi,
+  functionName: 'claim',
 })
 
 /**
@@ -20149,6 +20251,14 @@ export const useWriteSaleSetMinContribution =
   })
 
 /**
+ * Wraps __{@link useWriteContract}__ with `abi` set to __{@link saleAbi}__ and `functionName` set to `"setToken"`
+ */
+export const useWriteSaleSetToken = /*#__PURE__*/ createUseWriteContract({
+  abi: saleAbi,
+  functionName: 'setToken',
+})
+
+/**
  * Wraps __{@link useWriteContract}__ with `abi` set to __{@link saleAbi}__ and `functionName` set to `"withdraw"`
  */
 export const useWriteSaleWithdraw = /*#__PURE__*/ createUseWriteContract({
@@ -20169,6 +20279,14 @@ export const useSimulateSale = /*#__PURE__*/ createUseSimulateContract({
 export const useSimulateSaleBuy = /*#__PURE__*/ createUseSimulateContract({
   abi: saleAbi,
   functionName: 'buy',
+})
+
+/**
+ * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link saleAbi}__ and `functionName` set to `"claim"`
+ */
+export const useSimulateSaleClaim = /*#__PURE__*/ createUseSimulateContract({
+  abi: saleAbi,
+  functionName: 'claim',
 })
 
 /**
@@ -20241,6 +20359,14 @@ export const useSimulateSaleSetMinContribution =
   })
 
 /**
+ * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link saleAbi}__ and `functionName` set to `"setToken"`
+ */
+export const useSimulateSaleSetToken = /*#__PURE__*/ createUseSimulateContract({
+  abi: saleAbi,
+  functionName: 'setToken',
+})
+
+/**
  * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link saleAbi}__ and `functionName` set to `"withdraw"`
  */
 export const useSimulateSaleWithdraw = /*#__PURE__*/ createUseSimulateContract({
@@ -20254,6 +20380,13 @@ export const useSimulateSaleWithdraw = /*#__PURE__*/ createUseSimulateContract({
 export const useWatchSaleEvent = /*#__PURE__*/ createUseWatchContractEvent({
   abi: saleAbi,
 })
+
+/**
+ * Wraps __{@link useWatchContractEvent}__ with `abi` set to __{@link saleAbi}__ and `eventName` set to `"Claim"`
+ */
+export const useWatchSaleClaimEvent = /*#__PURE__*/ createUseWatchContractEvent(
+  { abi: saleAbi, eventName: 'Claim' },
+)
 
 /**
  * Wraps __{@link useWatchContractEvent}__ with `abi` set to __{@link saleAbi}__ and `eventName` set to `"Purchase"`
@@ -20444,6 +20577,15 @@ export const useWriteSaleTestTestBuyAboveMaximum =
   })
 
 /**
+ * Wraps __{@link useWriteContract}__ with `abi` set to __{@link saleTestAbi}__ and `functionName` set to `"testBuyAndClaim"`
+ */
+export const useWriteSaleTestTestBuyAndClaim =
+  /*#__PURE__*/ createUseWriteContract({
+    abi: saleTestAbi,
+    functionName: 'testBuyAndClaim',
+  })
+
+/**
  * Wraps __{@link useWriteContract}__ with `abi` set to __{@link saleTestAbi}__ and `functionName` set to `"testBuyBelowMinimum"`
  */
 export const useWriteSaleTestTestBuyBelowMinimum =
@@ -20503,6 +20645,15 @@ export const useSimulateSaleTestTestBuyAboveMaximum =
   })
 
 /**
+ * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link saleTestAbi}__ and `functionName` set to `"testBuyAndClaim"`
+ */
+export const useSimulateSaleTestTestBuyAndClaim =
+  /*#__PURE__*/ createUseSimulateContract({
+    abi: saleTestAbi,
+    functionName: 'testBuyAndClaim',
+  })
+
+/**
  * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link saleTestAbi}__ and `functionName` set to `"testBuyBelowMinimum"`
  */
 export const useSimulateSaleTestTestBuyBelowMinimum =
@@ -20526,6 +20677,15 @@ export const useSimulateSaleTestTestConstructor =
 export const useWatchSaleTestEvent = /*#__PURE__*/ createUseWatchContractEvent({
   abi: saleTestAbi,
 })
+
+/**
+ * Wraps __{@link useWatchContractEvent}__ with `abi` set to __{@link saleTestAbi}__ and `eventName` set to `"Claim"`
+ */
+export const useWatchSaleTestClaimEvent =
+  /*#__PURE__*/ createUseWatchContractEvent({
+    abi: saleTestAbi,
+    eventName: 'Claim',
+  })
 
 /**
  * Wraps __{@link useWatchContractEvent}__ with `abi` set to __{@link saleTestAbi}__ and `eventName` set to `"Purchase"`


### PR DESCRIPTION
Why:
* After the Sale ends, users need to be able to claim the tokens

How:
* Adding a `claim` function to the Sale contract that transfers the
  capped tokens to the user, along with any refund they might have, if
  the cap is below their initial contribution
