### PR TITLE
Disconnect improvement

### DIFF
--- a/packages/web-app/app/_lib/queries.tsx
+++ b/packages/web-app/app/_lib/queries.tsx
@@ -58,14 +58,14 @@ export const useFetchIdOSProfile = () => {
 };
 
 export const useFetchCredentials = () => {
-  const { sdk, hasSigner } = useIdOS();
+  const { sdk, hasSigner, address } = useIdOS();
 
   return useQuery({
-    queryKey: ['credentials'],
-    queryFn: async ({ queryKey: [tableName] }) => {
-      if (!sdk || !hasSigner) return null;
+    queryKey: ['credentials', address],
+    queryFn: async () => {
+      if (!sdk || !hasSigner || !address) return null;
 
-      const credentials = await sdk.data.list<idOSCredential>(tableName);
+      const credentials = await sdk.data.list<idOSCredential>('credentials');
       return credentials.map((credential) => ({
         ...credential,
         shares: credentials
@@ -76,7 +76,7 @@ export const useFetchCredentials = () => {
     select: (credentials) =>
       credentials &&
       credentials.filter((credential) => !credential.original_id),
-    enabled: !!(sdk && hasSigner),
+    enabled: !!(sdk && hasSigner && address),
   });
 };
 

--- a/packages/web-app/app/_providers/idos/context.tsx
+++ b/packages/web-app/app/_providers/idos/context.tsx
@@ -7,6 +7,7 @@ type TIdOSContextValue = {
   hasProfile: boolean;
   hasSigner: boolean;
   getProviderUrl: (address: string) => string;
+  disconnect: () => void;
   reset: () => Promise<void>;
 };
 

--- a/packages/web-app/app/_providers/react-query-wrapper-provider.tsx
+++ b/packages/web-app/app/_providers/react-query-wrapper-provider.tsx
@@ -5,7 +5,6 @@ const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       retry: 0,
-      // refetchOnWindowFocus: false,
       staleTime: Infinity,
     },
   },

--- a/packages/web-app/app/_ui/components/dialogs/apply-dialog/index.tsx
+++ b/packages/web-app/app/_ui/components/dialogs/apply-dialog/index.tsx
@@ -138,7 +138,9 @@ const UnlockKycData = ({ projectId }: TProjectIdProps) => {
   }
 
   return (
-    <p>Something went wrong and we could not retrieve your Kyc credentials</p>
+    <p className="mt-4">
+      Something went wrong and we could not retrieve your Kyc credentials
+    </p>
   );
 };
 

--- a/packages/web-app/app/_ui/components/dialogs/settings-dialog/disconnect.tsx
+++ b/packages/web-app/app/_ui/components/dialogs/settings-dialog/disconnect.tsx
@@ -1,12 +1,12 @@
 'use client';
 
 import { Button } from '../..';
-import { useDisconnect } from 'wagmi';
 import { Disconnect as DisconnectIcon } from '../../svg/disconnect';
 import { useDialog } from '@/app/_providers/dialog/context';
+import { useIdOS } from '@/app/_providers/idos';
 
 export const DisconnectMenu = () => {
-  const { disconnect } = useDisconnect();
+  const { disconnect } = useIdOS();
   const { close } = useDialog();
 
   return (
@@ -15,8 +15,8 @@ export const DisconnectMenu = () => {
       <Button
         variant="secondary"
         className="pb-0 pl-0 pr-0 pt-0 font-normal text-mono-950 hover:text-blue-400"
-        onClick={() => {
-          disconnect();
+        onClick={async () => {
+          await disconnect();
           close();
         }}
       >


### PR DESCRIPTION
Why:
- We want to improve the account switching flow

This change addresses the need by:
- Purging queries to try to force idOS to sync with current status 
- Making credentials query dependent on user address to avoid mismatches