### PR TITLE
Add NEXT_PUBLIC_DAPP_HOST environment variable

### DIFF
--- a/packages/web-app/.env.example
+++ b/packages/web-app/.env.example
@@ -9,6 +9,7 @@ NEXT_PUBLIC_IDOS_CONTRACT_ADDRESS_ARBITRUM=0x7D11563Bd4aA096CC83Fbe2cdd0557010dd
 NEXT_CITIZEND_WALLET_PRIVATE_KEY="private key"
 NEXT_PUBLIC_APPLY_OPEN=true
 NEXT_PUBLIC_CONTRIBUTE_OPEN=false
+NEXT_PUBLIC_DAPP_HOST=http://localhost:3000
 #test data derived from playground private key
 #idos_citizend_grantee = "0x2d49d75ca03041051a7488e28fc98906ac711873"
 #idos_citizend_encryption_public_key = "hPMGAtHXQlHhv30U8k8vQ7dyW70nm9OFLdA9lskwdRQ="

--- a/packages/web-app/app/_server/sales.ts
+++ b/packages/web-app/app/_server/sales.ts
@@ -38,8 +38,7 @@ export const saleDetails = async (): Promise<
   TProjectSaleDetails[] | TInternalError
 > => {
   try {
-    const headersList = headers();
-    const host = headersList.get('host');
+    const host = process.env.NEXT_PUBLIC_DAPP_HOST;
 
     // run requests in parallel
     const contractResults = await Promise.all([
@@ -70,10 +69,10 @@ export const saleDetails = async (): Promise<
         totalTokensForSale: contractResults[8],
         startRegistration: contractResults[9],
         endRegistration: contractResults[10],
-        url: `https://${host}/projects/citizend`,
-        logo: `https://${host}/project-citizend-logo.svg`,
-        background: `https://${host}/citizend-card-desktop.png`,
-        backgroundMobile: `https://${host}/citizend-card-mobile.png`,
+        url: `${host}/projects/citizend`,
+        logo: `${host}/project-citizend-logo.svg`,
+        background: `${host}/citizend-card-desktop.png`,
+        backgroundMobile: `${host}/citizend-card-mobile.png`,
       },
     ];
   } catch (error) {


### PR DESCRIPTION
Why:
* The introduction of the middleware that handles CORS broke the API for
  listing the sale details. Instead of relying on the `headers()`, we
  are reading the host value from an environment variable

How:
* Adding a environment variable to set the dApp host
