### PR TITLE
Add contribution mvp flow

### DIFF
--- a/packages/web-app/app/_server/sales.ts
+++ b/packages/web-app/app/_server/sales.ts
@@ -1,7 +1,13 @@
 'use server';
 
 import { ctzndSaleAbi, ctzndSaleAddress } from '@/wagmi.generated';
-import { createWalletClient, getContract, http, publicActions } from 'viem';
+import {
+  createWalletClient,
+  formatEther,
+  getContract,
+  http,
+  publicActions,
+} from 'viem';
 import { sepolia } from 'viem/chains';
 import { TProjectSaleDetails, TProjectStatus } from '../_types';
 import { TInternalError } from './types';
@@ -66,8 +72,8 @@ export const saleDetails = async (): Promise<
         maxTarget: contractResults[3],
         start: contractResults[4],
         end: contractResults[5],
-        minContribution: contractResults[6],
-        maxContribution: contractResults[7],
+        minContribution: formatEther(contractResults[6]),
+        maxContribution: formatEther(contractResults[7]),
         totalTokensForSale: contractResults[8],
         startRegistration: contractResults[9],
         endRegistration: contractResults[10],

--- a/packages/web-app/app/_types/index.ts
+++ b/packages/web-app/app/_types/index.ts
@@ -34,8 +34,8 @@ export type TProjectSaleDetails = {
   maxTarget: bigint;
   start: bigint;
   end: bigint;
-  minContribution: bigint;
-  maxContribution: bigint;
+  minContribution: string;
+  maxContribution: string;
   totalTokensForSale: bigint;
   startRegistration: bigint;
   endRegistration: bigint;

--- a/packages/web-app/app/_ui/components/button.tsx
+++ b/packages/web-app/app/_ui/components/button.tsx
@@ -33,7 +33,7 @@ export function Button({
       disabled={disabled}
       onClick={onClick}
       className={clsx(
-        'inline-flex select-none items-center justify-center gap-1 rounded-md px-6 py-4 font-medium',
+        'inline-flex select-none items-center justify-center gap-1 rounded-md px-6 py-4 font-medium transition-all duration-500 ease-in-out',
         variantClasses[variant],
         !disabled &&
           'focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-mono-400',

--- a/packages/web-app/app/_ui/components/input.tsx
+++ b/packages/web-app/app/_ui/components/input.tsx
@@ -31,7 +31,7 @@ const Units = ({ units }: { units: string | JSX.Element }) => {
 
 const getBaseStyles = (disabled: boolean, transparent: boolean) => {
   if (disabled) {
-    return 'bg-mono-200 text-mono-800';
+    return 'bg-blue-100 text-mono-800 border-mono-200';
   }
   if (transparent) {
     return 'border-mono-800 bg-transparent text-mono-50 placeholder:text-mono-400 focus:text-mono-50 active:text-mono-50';

--- a/packages/web-app/app/_ui/components/input.tsx
+++ b/packages/web-app/app/_ui/components/input.tsx
@@ -55,13 +55,6 @@ export const Input = memo(
     ...props
   }: IInputProps) => {
     const handleChange = useDebounce(onChange || defaultOnChange, 300);
-    const defaults =
-      variant === 'number'
-        ? { type: 'number', defaultValue: 0, min: 0 }
-        : {
-            type: 'text',
-            defaultValue: '',
-          };
 
     // handle enter key to submit form
     const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -84,7 +77,6 @@ export const Input = memo(
         </label>
         <div className="relative">
           <input
-            {...defaults}
             onKeyDown={handleKeyDown}
             disabled={disabled}
             className={clsx(

--- a/packages/web-app/app/_ui/components/wallet-button.tsx
+++ b/packages/web-app/app/_ui/components/wallet-button.tsx
@@ -33,14 +33,7 @@ export function WalletButton() {
   return (
     <div className="h-14">
       <ConnectButton.Custom>
-        {({
-          account,
-          chain,
-          openAccountModal,
-          openChainModal,
-          openConnectModal,
-          mounted,
-        }) => {
+        {({ account, chain, openChainModal, openConnectModal, mounted }) => {
           const connected = mounted && account && chain && isConnected;
 
           if (!mounted)
@@ -72,6 +65,10 @@ export function WalletButton() {
                 <ConnectedButton displayBalance={account.displayBalance} />
               );
             }
+
+            return (
+              <div className="h-14 w-44 animate-pulse rounded-md bg-gradient-to-br from-mono-800 to-mono-900" />
+            );
           })();
         }}
       </ConnectButton.Custom>

--- a/packages/web-app/app/_ui/project/project-content.tsx
+++ b/packages/web-app/app/_ui/project/project-content.tsx
@@ -8,10 +8,10 @@ import { TokenMetrics } from './token-metrics';
 import { ApplyButton } from './apply-button';
 import { useFetchProjectsSaleDetails } from '@/app/_lib/queries';
 import { useProject } from '@/app/_providers/project/context';
-import { Spinner } from '../components/svg/spinner';
 import { ProjectContribution } from './project-contribution';
 import { useHasCitizendGrant, useHasProjectGrant } from '@/app/_lib/hooks';
 import { AppliedSuccess } from './applied-success';
+import { CardSkeleton } from '../components/skeletons/card-skeleton';
 
 const generateTabClassName = ({ selected }: { selected: boolean }) =>
   clsx(
@@ -36,7 +36,14 @@ export const ProjectContent = () => {
 
   if (isLoading || (!data && !isError)) {
     return (
-      <Spinner className="mx-auto h-40 w-40 animate-spin-slow text-mono-50" />
+      <div className="grid grid-cols-1 gap-6  md:grid-cols-2">
+        <CardSkeleton className="h-[544px]" />
+        <div className="flex flex-col gap-6">
+          <CardSkeleton className="h-36" />
+          <CardSkeleton className="h-80" />
+          <CardSkeleton className="h-24" />
+        </div>
+      </div>
     );
   }
 
@@ -125,7 +132,9 @@ export const ProjectContent = () => {
             maxContribution={maxContribution}
             totalTokensForSale={totalTokensForSale}
           />
-          {hasGrant ? <AppliedSuccess /> : null}
+          {hasGrant && process.env.NEXT_PUBLIC_APPLY_OPEN === 'true' ? (
+            <AppliedSuccess />
+          ) : null}
           {process.env.NEXT_PUBLIC_APPLY_OPEN === 'true' && !hasGrant ? (
             <ApplyButton isLoading={isLoading} error={errorLoadingGrant} />
           ) : null}

--- a/packages/web-app/app/_ui/project/project-contribution.tsx
+++ b/packages/web-app/app/_ui/project/project-contribution.tsx
@@ -13,6 +13,7 @@ import {
 } from '@/wagmi.generated';
 import { formatEther } from 'viem';
 import { usdValue } from '../utils/intl-formaters/usd-value';
+import { Spinner } from '../components/svg/spinner';
 
 const useMaxParticipants = () => {
   const { data: maxTarget } = useReadCtzndSaleMaxTarget();
@@ -61,6 +62,7 @@ export const ProjectContribution = () => {
     useWriteCtzndSaleBuy();
   const maxParticipants = useMaxParticipants();
   const onSubmit = () => {
+    if (amount <= 0) return;
     writeContract({ args: [BigInt(amount)] });
   };
 
@@ -82,6 +84,8 @@ export const ProjectContribution = () => {
           error={errorMessage}
           className="col-span-2 md:col-span-1"
           onSubmit={onSubmit}
+          defaultValue={amount}
+          min={0}
         />
         <Input
           label="You Get"
@@ -118,11 +122,12 @@ export const ProjectContribution = () => {
         </p>
       </div>
       <Button
-        variant="primary"
         className="w-full rounded-none"
         onClick={onSubmit}
+        disabled={amount <= 0}
+        variant={amount <= 0 ? 'primary-disabled' : 'primary'}
       >
-        Contribute
+        {isPending ? <Spinner /> : 'Contribute'}
       </Button>
     </div>
   );

--- a/packages/web-app/app/_ui/project/project-contribution.tsx
+++ b/packages/web-app/app/_ui/project/project-contribution.tsx
@@ -1,7 +1,43 @@
 'use client';
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { Input } from '../components/input';
 import { Button } from '../components';
+import {
+  useReadCtzndSaleMaxContribution,
+  useReadCtzndSaleMinContribution,
+  useReadCtzndSaleInvestorCount,
+  useReadCtzndSaleMaxTarget,
+  useReadCtzndSaleMinTarget,
+  useWriteCtzndSaleBuy,
+  useReadCtzndSaleRate,
+} from '@/wagmi.generated';
+import { formatEther } from 'viem';
+import { usdValue } from '../utils/intl-formaters/usd-value';
+
+const useMaxParticipants = () => {
+  const { data: maxTarget } = useReadCtzndSaleMaxTarget();
+  const { data: minTarget } = useReadCtzndSaleMinTarget();
+
+  if (!maxTarget || !minTarget) return 0;
+
+  return BigInt(maxTarget) - BigInt(minTarget);
+};
+
+const getErrorMessage = (amount: number, error: any) => {
+  if (amount < 0) {
+    return 'The amount must be greater than 0';
+  }
+
+  if (error?.shortMessage) {
+    return error.shortMessage;
+  }
+
+  if (error) {
+    return error?.message || 'An error occurred';
+  }
+
+  return null;
+};
 
 export const ProjectContribution = () => {
   const [amount, setAmount] = useState(0);
@@ -12,6 +48,23 @@ export const ProjectContribution = () => {
     },
     [],
   );
+  const { data: maxContribution } = useReadCtzndSaleMaxContribution();
+  const { data: minContribution } = useReadCtzndSaleMinContribution();
+  const { data: investorCount } = useReadCtzndSaleInvestorCount();
+  const { data: saleRate } = useReadCtzndSaleRate();
+  const ctndTokens = useMemo(
+    () => (saleRate && amount ? BigInt(amount) * BigInt(saleRate) : 0),
+    [saleRate, amount],
+  );
+
+  const { writeContract, data, isError, isPending, isPaused, error } =
+    useWriteCtzndSaleBuy();
+  const maxParticipants = useMaxParticipants();
+  const onSubmit = () => {
+    writeContract({ args: [BigInt(amount)] });
+  };
+
+  const errorMessage = getErrorMessage(amount, error);
 
   return (
     <div className="flex w-full flex-col rounded-lg bg-mono-50 text-mono-950">
@@ -26,39 +79,49 @@ export const ProjectContribution = () => {
           type="number"
           id="usdc-amount"
           units="USDC"
-          error={amount < 0 ? 'The amount must be greater than 0' : ''}
+          error={errorMessage}
           className="col-span-2 md:col-span-1"
+          onSubmit={onSubmit}
         />
         <Input
           label="You Get"
           type="number"
           id="ctnd-amount"
-          units="CTND"
+          units="CTND*"
           disabled
+          value={ctndTokens.toString()}
           className="col-span-2 md:col-span-1"
         />
         <div className="md:col-span-2">
           <p className="text-mono-800">Current price</p>
           <p>0.1 USDC*</p>
         </div>
-        <div className="md:col-span-2">
+        <div>
           <p className="text-mono-800">Min. contribution</p>
-          <p>200 USDC</p>
+          <p>{minContribution ? usdValue(formatEther(minContribution)) : ''}</p>
+        </div>
+        <div>
+          <p className="text-mono-800">Max. contribution</p>
+          <p>{maxContribution ? usdValue(formatEther(maxContribution)) : ''}</p>
         </div>
         <div>
           <p className="text-mono-800">Current contributors</p>
-          <p>4435</p>
+          <p>{investorCount?.toString()}</p>
         </div>
         <div>
           <p className="text-mono-800">Max. participants</p>
-          <p>10000</p>
+          <p>{maxParticipants.toString()}</p>
         </div>
         <p className="col-span-2 text-mono-800">
           *Contribution amount/token allocation amount fluctuates depending on
           the number of contributors and their desired contribution.
         </p>
       </div>
-      <Button variant="primary" className="w-full rounded-none">
+      <Button
+        variant="primary"
+        className="w-full rounded-none"
+        onClick={onSubmit}
+      >
         Contribute
       </Button>
     </div>

--- a/packages/web-app/app/_ui/project/project-contribution.tsx
+++ b/packages/web-app/app/_ui/project/project-contribution.tsx
@@ -14,6 +14,7 @@ import {
 import { formatEther } from 'viem';
 import { usdValue } from '../utils/intl-formaters/usd-value';
 import { Spinner } from '../components/svg/spinner';
+import { number } from '../utils/intl-formaters/number';
 
 const useMaxParticipants = () => {
   const { data: maxTarget } = useReadCtzndSaleMaxTarget();
@@ -65,7 +66,6 @@ export const ProjectContribution = () => {
     if (amount <= 0) return;
     writeContract({ args: [BigInt(amount)] });
   };
-
   const errorMessage = getErrorMessage(amount, error);
 
   return (
@@ -102,19 +102,27 @@ export const ProjectContribution = () => {
         </div>
         <div>
           <p className="text-mono-800">Min. contribution</p>
-          <p>{minContribution ? usdValue(formatEther(minContribution)) : ''}</p>
+          <p>
+            {minContribution !== undefined
+              ? usdValue(formatEther(minContribution))
+              : ''}
+          </p>
         </div>
         <div>
           <p className="text-mono-800">Max. contribution</p>
-          <p>{maxContribution ? usdValue(formatEther(maxContribution)) : ''}</p>
+          <p>
+            {maxContribution !== undefined
+              ? usdValue(formatEther(maxContribution))
+              : ''}
+          </p>
         </div>
         <div>
           <p className="text-mono-800">Current contributors</p>
-          <p>{investorCount?.toString()}</p>
+          <p>{number(investorCount || 0)}</p>
         </div>
         <div>
           <p className="text-mono-800">Max. participants</p>
-          <p>{maxParticipants.toString()}</p>
+          <p>{number(maxParticipants)}</p>
         </div>
         <p className="col-span-2 text-mono-800">
           *Contribution amount/token allocation amount fluctuates depending on

--- a/packages/web-app/app/_ui/project/token-metrics.tsx
+++ b/packages/web-app/app/_ui/project/token-metrics.tsx
@@ -5,8 +5,8 @@ type TTokenMetricsProps = {
   minTarget: bigint;
   maxTarget: bigint;
   totalTokensForSale: bigint;
-  minContribution: bigint;
-  maxContribution: bigint;
+  minContribution: string;
+  maxContribution: string;
 };
 
 const ProgressBar = ({

--- a/packages/web-app/app/_ui/projects/project-card.tsx
+++ b/packages/web-app/app/_ui/projects/project-card.tsx
@@ -7,23 +7,9 @@ import { ArrowRight } from '../components/svg/arrow-right';
 import { getRelativePath } from '../utils/getRelativePath';
 import { BannerImage } from './banner-image';
 import { Status } from './status';
-
-const formatDateRange = (start: bigint, end: bigint) => {
-  try {
-    const dateFormatter = new Intl.DateTimeFormat('default', {
-      month: 'short',
-      day: 'numeric',
-      year: '2-digit',
-    });
-    const startDate = Number(start);
-    const endDate = Number(end);
-
-    return dateFormatter.formatRange(startDate, endDate);
-  } catch (error) {
-    console.error(error);
-    return '';
-  }
-};
+import { usdValue } from '../utils/intl-formaters/usd-value';
+import { usdRange } from '../utils/intl-formaters/usd-range';
+import { shortDateRange } from '../utils/intl-formaters/date-range';
 
 const Upcoming = ({
   minTarget,
@@ -32,14 +18,8 @@ const Upcoming = ({
   endRegistration,
   start,
 }: TProjectSaleDetails) => {
-  const rangeFormatter = new Intl.NumberFormat('default', {
-    style: 'currency',
-    currency: 'USD',
-    currencyDisplay: 'narrowSymbol',
-    maximumSignificantDigits: 1,
-  });
-  const targetedRaise = rangeFormatter.formatRange(minTarget, maxTarget);
-  const registerPeriod = formatDateRange(startRegistration, endRegistration);
+  const targetedRaise = usdRange(minTarget, maxTarget);
+  const registerPeriod = shortDateRange(startRegistration, endRegistration);
   const { days, hours, minutes, seconds } = useCountdown(start);
 
   return (
@@ -72,20 +52,9 @@ const FullData = ({
   maxContribution,
   totalTokensForSale,
 }: TProjectSaleDetails) => {
-  const rangeFormatter = new Intl.NumberFormat('default', {
-    style: 'currency',
-    currency: 'USD',
-    currencyDisplay: 'narrowSymbol',
-    maximumSignificantDigits: 1,
-  });
-  const valueFormatter = new Intl.NumberFormat('default', {
-    style: 'currency',
-    currency: 'USD',
-    currencyDisplay: 'narrowSymbol',
-  });
-  const targetedRaise = rangeFormatter.formatRange(minTarget, maxTarget);
-  const maxPrice = valueFormatter.format(maxContribution);
-  const minPrice = valueFormatter.format(minContribution);
+  const targetedRaise = usdRange(minTarget, maxTarget);
+  const maxPrice = usdValue(maxContribution);
+  const minPrice = usdValue(minContribution);
   const totalTokens = new Intl.NumberFormat('default').format(
     totalTokensForSale,
   );
@@ -145,7 +114,7 @@ export const ProjectCard = (props: TProjectSaleDetails) => {
 
   return (
     <Link
-      className="relative flex flex-col gap-4 rounded-2.5xl bg-mono-900 p-6 md:p-8"
+      className="relative flex flex-col gap-4 rounded-2.5xl bg-mono-900 p-6 md:max-w-md md:p-8"
       href={href}
     >
       <Status status={status} />

--- a/packages/web-app/app/_ui/utils/intl-formaters/date-range.ts
+++ b/packages/web-app/app/_ui/utils/intl-formaters/date-range.ts
@@ -6,6 +6,24 @@ const dateFormatter = new Intl.DateTimeFormat('en-US', {
   timeZoneName: 'short',
 });
 
+const shortDateFormatter = new Intl.DateTimeFormat('default', {
+  month: 'short',
+  day: 'numeric',
+  year: '2-digit',
+});
+
+export const shortDateRange = (start: bigint, end: bigint) => {
+  try {
+    const startDate = Number(start);
+    const endDate = Number(end);
+
+    return shortDateFormatter.formatRange(startDate, endDate);
+  } catch (error) {
+    console.error(error);
+    return '';
+  }
+};
+
 export const dateRange = (start: bigint, end: bigint) => {
   try {
     const startDate = parseInt(start.toString());

--- a/packages/web-app/app/_ui/utils/intl-formaters/number.ts
+++ b/packages/web-app/app/_ui/utils/intl-formaters/number.ts
@@ -1,0 +1,2 @@
+export const number = (value: number | bigint) =>
+  new Intl.NumberFormat('default').format(value);

--- a/packages/web-app/app/_ui/utils/intl-formaters/usd-value.ts
+++ b/packages/web-app/app/_ui/utils/intl-formaters/usd-value.ts
@@ -4,4 +4,15 @@ const valueFormatter = new Intl.NumberFormat('default', {
   currencyDisplay: 'narrowSymbol',
 });
 
-export const usdValue = (value: bigint) => valueFormatter.format(value);
+const getValue = (value: bigint | number | string): number | bigint => {
+  if (typeof value === 'string') {
+    return parseFloat(value);
+  }
+  return value;
+};
+
+export const usdValue = (initialValue: bigint | number | string) => {
+  const value = getValue(initialValue);
+
+  return valueFormatter.format(value);
+};

--- a/packages/web-app/middleware.ts
+++ b/packages/web-app/middleware.ts
@@ -1,42 +1,45 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server';
 
-const allowedOrigins = ['https://citizend-staging.webflow.io', 'https://citizend.xyz']
+const allowedOrigins = [
+  'https://citizend-staging.webflow.io',
+  'https://citizend.xyz',
+];
 
 const corsOptions = {
   'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
   'Access-Control-Allow-Headers': 'Content-Type, Authorization',
-}
+};
 
 export function middleware(request: NextRequest) {
   // Check the origin from the request
-  const origin = request.headers.get('origin') ?? ''
-  const isAllowedOrigin = allowedOrigins.includes(origin)
+  const origin = request.headers.get('origin') ?? '';
+  const isAllowedOrigin = allowedOrigins.includes(origin);
 
   // Handle preflighted requests
-  const isPreflight = request.method === 'OPTIONS'
+  const isPreflight = request.method === 'OPTIONS';
 
   if (isPreflight) {
     const preflightHeaders = {
       ...(isAllowedOrigin && { 'Access-Control-Allow-Origin': origin }),
       ...corsOptions,
-    }
-    return NextResponse.json({}, { headers: preflightHeaders })
+    };
+    return NextResponse.json({}, { headers: preflightHeaders });
   }
 
   // Handle simple requests
-  const response = NextResponse.next()
+  const response = NextResponse.next();
 
   if (isAllowedOrigin) {
-    response.headers.set('Access-Control-Allow-Origin', origin)
+    response.headers.set('Access-Control-Allow-Origin', origin);
   }
 
   Object.entries(corsOptions).forEach(([key, value]) => {
-    response.headers.set(key, value)
-  })
+    response.headers.set(key, value);
+  });
 
-  return response
+  return response;
 }
 
 export const config = {
   matcher: '/api/:path*',
-}
+};


### PR DESCRIPTION
Why:
- We want to test contribution flow of the token sale

This change addresses the need by:
- Read values directly from the project contract using wagmi
- Adding contribute action to the contribution card (MVP)
- Updating sale endpoint to parse the eth values so it doesn't break our parsed values and external website

Note: `Project-contribution.tsx` isn't optimized or properly warded, but the goal is to be able to test the contract functions once the contract dates are fixed