### PR TITLE
Include www subdomain for CORS

### DIFF
--- a/packages/web-app/middleware.ts
+++ b/packages/web-app/middleware.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from 'next/server';
 const allowedOrigins = [
   'https://citizend-staging.webflow.io',
   'https://citizend.xyz',
+  'https://www.citizend.xyz',
 ];
 
 const corsOptions = {


### PR DESCRIPTION
Why:
* Landing page also make requests to the API from the www subdomain

How:
* Including a `https://www.citizend.xyz` domain in allowed CORS domains
