### PR TITLE
Server route to generate Merkle Root

### DIFF
--- a/.github/workflows/web-test.yml
+++ b/.github/workflows/web-test.yml
@@ -52,3 +52,5 @@ jobs:
         run: yarn workspace @discovery-dao/web-app build
         env:
           NEXT_PUBLIC_WC_PROJECT_ID: ${{ secrets.NEXT_PUBLIC_WC_PROJECT_ID }}
+          NEXT_CITIZEND_WALLET_PRIVATE_KEY: ${{ secrets.NEXT_CITIZEND_WALLET_PRIVATE_KEY }}
+          NEXT_PUBLIC_IDOS_NODE_URL: ${{ secrets.NEXT_PUBLIC_IDOS_NODE_URL }}

--- a/packages/web-app/app/api/generate/route.ts
+++ b/packages/web-app/app/api/generate/route.ts
@@ -1,13 +1,15 @@
-export async function GET(_request: Request) {
-  // const root = await generateMerkleRoot();
-  //
-  // if (typeof root === 'object' && 'error' in root) {
-  //   return new Response(`Generate root error: ${root.error}`, {
-  //     status: 500,
-  //   });
-  // }
-  //
-  // return Response.json(root);
+import { generateMerkleRoot } from "@/app/_server/projects/generate-merkle-root";
 
-  return new Response('root');
+export const revalidate = 0;
+
+export async function GET(_request: Request) {
+  const root = await generateMerkleRoot();
+
+  if (typeof root === 'object' && 'error' in root) {
+    return new Response(`Generate root error: ${root.error}`, {
+      status: 500,
+    });
+  }
+
+  return Response.json(root);
 }


### PR DESCRIPTION
Why:
* So we can call this to get a merkle root whenever we need to, for testing purposes

How:
* Adding `const revalidate = 0` to prevent NextJS cache
* Adding the needed env vars to the Github Actions workflow